### PR TITLE
Primitive content on value.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcder"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]
 description = "Handling of data encoded in BER, CER, and DER."
 repository = "https://github.com/nlnetlabs/bcder"

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,13 +5,15 @@
 Breaking Changes
 
 *  `PrimitiveContent`’s methods take `self` instead of `&self`. This
-   avoids the lifetime argument in `Primitive`, its encoder.
+   avoids the lifetime argument in `Primitive`, its encoder. [(#6)]
 
 New
 
 Bug Fixes
 
 Dependencies
+
+[(#6)]: https://github.com/NLnetLabs/bcder/pull/6
 
 
 ## 0.1.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,11 @@
 # Change Log
 
-## 0.1.1
+## 0.2.0
 
 Breaking Changes
+
+*  `PrimitiveContent`’s methods take `self` instead of `&self`. This
+   avoids the lifetime argument in `Primitive`, its encoder.
 
 New
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -358,15 +358,15 @@ impl hash::Hash for Integer {
 
 //--- encode::PrimitiveContent
 
-impl PrimitiveContent for Integer {
+impl<'a> PrimitiveContent for &'a Integer {
     const TAG: Tag = Tag::INTEGER;
 
-    fn encoded_len(&self, _mode: Mode) -> usize {
+    fn encoded_len(self, _mode: Mode) -> usize {
         self.0.len()
     }
 
     fn write_encoded<W: io::Write>(
-        &self,
+        self,
         _mode: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {
@@ -537,15 +537,15 @@ impl AsRef<[u8]> for Unsigned {
 
 //--- endode::PrimitiveContent
 
-impl PrimitiveContent for Unsigned {
+impl<'a> PrimitiveContent for &'a Unsigned {
     const TAG: Tag = Tag::INTEGER;
 
-    fn encoded_len(&self, mode: Mode) -> usize {
+    fn encoded_len(self, mode: Mode) -> usize {
         self.0.encoded_len(mode)
     }
 
     fn write_encoded<W: io::Write>(
-        &self,
+        self,
         mode: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub use self::int::{Integer, Unsigned};
 pub use self::mode::Mode;
 pub use self::oid::{ConstOid, Oid};
 pub use self::string::{
+    BytesString,
     BitString, OctetString,
     Ia5String, NumericString, PrintableString, Utf8String,
 };

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -125,12 +125,12 @@ impl<T: AsRef<[u8]>> Oid<T> {
 
     /// Returns a value encoder for the value using the natural tag.
     pub fn encode<'a>(&'a self) -> impl encode::Values + 'a {
-        <Self as encode::PrimitiveContent>::encode(self)
+        encode::PrimitiveContent::encode(self)
     }
 
     /// Returns a value encoder for the value using the given tag.
     pub fn encode_as<'a>(&'a self, tag: Tag) -> impl encode::Values + 'a {
-        <Self as encode::PrimitiveContent>::encode_as(self, tag)
+        encode::PrimitiveContent::encode_as(self, tag)
     }
 }
 
@@ -204,15 +204,15 @@ impl<T: AsRef<[u8]>> fmt::Display for Oid<T> {
 
 //--- encode::PrimitiveContent
 
-impl<T: AsRef<[u8]>> encode::PrimitiveContent for Oid<T> {
+impl<'a, T: AsRef<[u8]>> encode::PrimitiveContent for &'a Oid<T> {
     const TAG: Tag = Tag::OID;
 
-    fn encoded_len(&self, _: Mode) -> usize {
+    fn encoded_len(self, _: Mode) -> usize {
         self.0.as_ref().len()
     }
 
     fn write_encoded<W: io::Write>(
-        &self,
+        self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {

--- a/src/string/bit.rs
+++ b/src/string/bit.rs
@@ -200,15 +200,15 @@ impl BitString {
 
 //--- PrimitiveContent
 
-impl encode::PrimitiveContent for BitString {
+impl<'a> encode::PrimitiveContent for &'a BitString {
     const TAG: Tag = Tag::BIT_STRING;
 
-    fn encoded_len(&self, _: Mode) -> usize {
+    fn encoded_len(self, _: Mode) -> usize {
         self.bits.len() + 1
     }
 
     fn write_encoded<W: io::Write>(
-        &self,
+        self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {

--- a/src/string/bytes.rs
+++ b/src/string/bytes.rs
@@ -1,0 +1,114 @@
+//! Bytes String.
+//!
+//! This is an internal module. It’s public items are re-exported by the
+//! parent.
+
+use std::{ops, str};
+use std::borrow::Borrow;
+use bytes::Bytes;
+
+
+//------------ BytesString ---------------------------------------------------
+
+/// A string atop a bytes value.
+///
+/// This types wraps a `Bytes` value that contains a correctly encoded
+/// string and provides a `str` interface to it.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct BytesString(Bytes);
+
+impl BytesString {
+    /// Creates a new bytes string without checking the content.
+    pub unsafe fn from_utf8_unchecked(bytes: Bytes) -> Self {
+        BytesString(bytes)
+    }
+
+    /// Converts a bytes value into a bytes string.
+    pub fn from_utf8(bytes: Bytes) -> Result<Self, str::Utf8Error> {
+        let _ = str::from_utf8(&bytes)?;
+        Ok(unsafe { Self::from_utf8_unchecked(bytes) })
+    }
+
+    /// Creates an empty bytes string.
+    pub fn empty() -> Self {
+        unsafe { Self::from_utf8_unchecked(Bytes::new()) }
+    }
+
+    /// Returns a reference to the underlying bytes value.
+    pub fn as_bytes(&self) -> &Bytes {
+        &self.0
+    }
+
+    /// Returns a reference to the string content.
+    pub fn as_str(&self) -> &str {
+        unsafe { str::from_utf8_unchecked(self.as_slice()) }
+    }
+
+    /// Returns a reference to the raw byte slice.
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+
+//--- From
+
+impl From<String> for BytesString {
+    fn from(s: String) -> Self {
+        unsafe { Self::from_utf8_unchecked(Bytes::from(s.into_bytes())) }
+    }
+}
+
+impl<'a> From<&'a str> for BytesString {
+    fn from(s: &'a str) -> Self {
+        unsafe { Self::from_utf8_unchecked(Bytes::from(s.as_bytes())) }
+    }
+}
+
+
+//--- Deref, AsRef and Borrow
+
+impl ops::Deref for BytesString {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<Bytes> for BytesString {
+    fn as_ref(&self) -> &Bytes {
+        self.as_bytes()
+    }
+}
+
+impl AsRef<str> for BytesString {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<[u8]> for BytesString {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl Borrow<Bytes> for BytesString {
+    fn borrow(&self) -> &Bytes {
+        self.as_bytes()
+    }
+}
+
+impl Borrow<str> for BytesString {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<[u8]> for BytesString {
+    fn borrow(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+

--- a/src/string/bytes.rs
+++ b/src/string/bytes.rs
@@ -3,7 +3,7 @@
 //! This is an internal module. It’s public items are re-exported by the
 //! parent.
 
-use std::{ops, str};
+use std::{cmp, fmt, ops, str};
 use std::borrow::Borrow;
 use bytes::Bytes;
 
@@ -14,7 +14,7 @@ use bytes::Bytes;
 ///
 /// This types wraps a `Bytes` value that contains a correctly encoded
 /// string and provides a `str` interface to it.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Hash)]
 pub struct BytesString(Bytes);
 
 impl BytesString {
@@ -47,6 +47,14 @@ impl BytesString {
     /// Returns a reference to the raw byte slice.
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+//--- Default
+
+impl Default for BytesString {
+    fn default() -> Self {
+        Self::empty()
     }
 }
 
@@ -109,6 +117,41 @@ impl Borrow<str> for BytesString {
 impl Borrow<[u8]> for BytesString {
     fn borrow(&self) -> &[u8] {
         self.as_slice()
+    }
+}
+
+
+//--- PartialEq and Eq
+
+impl<T: AsRef<str>> PartialEq<T> for BytesString {
+    fn eq(&self, other: &T) -> bool {
+        self.as_str().eq(other.as_ref())
+    }
+}
+
+impl Eq for BytesString { }
+
+
+//--- PartialOrd and Ord
+
+impl<T: AsRef<str>> PartialOrd<T> for BytesString {
+    fn partial_cmp(&self, other: &T) -> Option<cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_ref())
+    }
+}
+
+impl Ord for BytesString {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for BytesString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.as_str().fmt(f)
     }
 }
 

--- a/src/string/bytes.rs
+++ b/src/string/bytes.rs
@@ -48,6 +48,10 @@ impl BytesString {
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_ref()
     }
+
+    pub fn into_bytes(self) -> Bytes {
+        self.0
+    }
 }
 
 //--- Default

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -35,6 +35,7 @@
 //--- Re-exports
 
 pub use self::bit::{BitString, BitStringIter};
+pub use self::bytes::BytesString;
 pub use self::restricted::{
     CharSet, CharSetError,
     RestrictedString, RestrictedStringChars,
@@ -48,6 +49,7 @@ pub use self::octet::{
 //--- Private modules
 
 mod bit;
+mod bytes;
 mod restricted;
 mod octet;
 


### PR DESCRIPTION
This PR moves `PrimitiveContent`’s methods to take `self` by value instead of by reference. This allows its encoder to not have a lifetime value which causes trouble along the way.