### PR TITLE
PrimitiveContent takes self by value.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcder"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]
 description = "Handling of data encoded in BER, CER, and DER."
 repository = "https://github.com/nlnetlabs/bcder"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,19 @@
 # Change Log
 
-## 0.1.1
+## 0.2.0
 
 Breaking Changes
+
+*  `PrimitiveContent`’s methods take `self` instead of `&self`. This
+   avoids the lifetime argument in `Primitive`, its encoder. [(#6)]
 
 New
 
 Bug Fixes
 
 Dependencies
+
+[(#6)]: https://github.com/NLnetLabs/bcder/pull/6
 
 
 ## 0.1.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 Breaking Changes
 
 *  `PrimitiveContent`’s methods take `self` instead of `&self`. This
-   avoids the lifetime argument in `Primitive`, its encoder. [(#6)]
+   avoids the lifetime argument in `Primitive`, its encoder. [(#7)]
 
 New
 
@@ -13,7 +13,7 @@ Bug Fixes
 
 Dependencies
 
-[(#6)]: https://github.com/NLnetLabs/bcder/pull/6
+[(#7)]: https://github.com/NLnetLabs/bcder/pull/7
 
 
 ## 0.1.0

--- a/src/int.rs
+++ b/src/int.rs
@@ -358,15 +358,15 @@ impl hash::Hash for Integer {
 
 //--- encode::PrimitiveContent
 
-impl PrimitiveContent for Integer {
+impl<'a> PrimitiveContent for &'a Integer {
     const TAG: Tag = Tag::INTEGER;
 
-    fn encoded_len(&self, _mode: Mode) -> usize {
+    fn encoded_len(self, _mode: Mode) -> usize {
         self.0.len()
     }
 
     fn write_encoded<W: io::Write>(
-        &self,
+        self,
         _mode: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {
@@ -537,15 +537,15 @@ impl AsRef<[u8]> for Unsigned {
 
 //--- endode::PrimitiveContent
 
-impl PrimitiveContent for Unsigned {
+impl<'a> PrimitiveContent for &'a Unsigned {
     const TAG: Tag = Tag::INTEGER;
 
-    fn encoded_len(&self, mode: Mode) -> usize {
+    fn encoded_len(self, mode: Mode) -> usize {
         self.0.encoded_len(mode)
     }
 
     fn write_encoded<W: io::Write>(
-        &self,
+        self,
         mode: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -125,12 +125,12 @@ impl<T: AsRef<[u8]>> Oid<T> {
 
     /// Returns a value encoder for the value using the natural tag.
     pub fn encode<'a>(&'a self) -> impl encode::Values + 'a {
-        <Self as encode::PrimitiveContent>::encode(self)
+        encode::PrimitiveContent::encode(self)
     }
 
     /// Returns a value encoder for the value using the given tag.
     pub fn encode_as<'a>(&'a self, tag: Tag) -> impl encode::Values + 'a {
-        <Self as encode::PrimitiveContent>::encode_as(self, tag)
+        encode::PrimitiveContent::encode_as(self, tag)
     }
 }
 
@@ -204,15 +204,15 @@ impl<T: AsRef<[u8]>> fmt::Display for Oid<T> {
 
 //--- encode::PrimitiveContent
 
-impl<T: AsRef<[u8]>> encode::PrimitiveContent for Oid<T> {
+impl<'a, T: AsRef<[u8]>> encode::PrimitiveContent for &'a Oid<T> {
     const TAG: Tag = Tag::OID;
 
-    fn encoded_len(&self, _: Mode) -> usize {
+    fn encoded_len(self, _: Mode) -> usize {
         self.0.as_ref().len()
     }
 
     fn write_encoded<W: io::Write>(
-        &self,
+        self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {

--- a/src/string/bit.rs
+++ b/src/string/bit.rs
@@ -200,15 +200,15 @@ impl BitString {
 
 //--- PrimitiveContent
 
-impl encode::PrimitiveContent for BitString {
+impl<'a> encode::PrimitiveContent for &'a BitString {
     const TAG: Tag = Tag::BIT_STRING;
 
-    fn encoded_len(&self, _: Mode) -> usize {
+    fn encoded_len(self, _: Mode) -> usize {
         self.bits.len() + 1
     }
 
     fn write_encoded<W: io::Write>(
-        &self,
+        self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {


### PR DESCRIPTION
This PR moves `PrimitiveContent`’s methods to take `self` by value instead of by reference. This allows its encoder to not have a lifetime value which causes trouble along the way.