### PR TITLE
Primitive encoder takes content by value

### DIFF
--- a/src/encode/primitive.rs
+++ b/src/encode/primitive.rs
@@ -65,6 +65,16 @@ pub trait PrimitiveContent: Sized {
     fn encode_as(self, tag: Tag) -> Primitive<Self> {
         Primitive { tag, prim: self }
     }
+
+    /// Returns a value encoder for a reference using the natural tag.
+    fn encode_ref(&self) -> Primitive<&Self> {
+        self.encode_ref_as(Self::TAG)
+    }
+
+    /// Returns a value encoder for a reference using the given tag.
+    fn encode_ref_as(&self, tag: Tag) -> Primitive<&Self> {
+        Primitive { tag, prim: self }
+    }
 }
 
 

--- a/src/encode/primitive.rs
+++ b/src/encode/primitive.rs
@@ -28,16 +28,16 @@ use super::values::Values;
 ///
 /// [`encode`]: #tymethod.encode
 /// [`encode_as`]: #tymethod.encode_as
-pub trait PrimitiveContent: Copy {
+pub trait PrimitiveContent: Sized {
     /// The natural tag of an encoded value of this type.
     const TAG: Tag;
 
     /// Returns the length of the encoded content of this type.
-    fn encoded_len(self, mode: Mode) -> usize;
+    fn encoded_len(&self, mode: Mode) -> usize;
 
     /// Writes the encoded content to a writer.
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         mode: Mode,
         target: &mut W
     ) -> Result<(), io::Error>;
@@ -73,20 +73,20 @@ pub trait PrimitiveContent: Copy {
 impl PrimitiveContent for u8 {
     const TAG: Tag = Tag::INTEGER;
 
-    fn encoded_len(self, _: Mode) -> usize {
-        if self > 0x7F { 2 }
+    fn encoded_len(&self, _: Mode) -> usize {
+        if *self > 0x7F { 2 }
         else { 1 }
     }
 
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {
-        if self > 0x7F {
+        if *self > 0x7F {
             target.write(&[0])?;
         }
-        target.write(&[self])?;
+        target.write(&[*self])?;
         Ok(())
     }
 }
@@ -96,8 +96,8 @@ macro_rules! unsigned_content {
         impl PrimitiveContent for $type {
             const TAG: Tag = Tag::INTEGER;
 
-            fn encoded_len(self, _: Mode) -> usize {
-                if self == 0 {
+            fn encoded_len(&self, _: Mode) -> usize {
+                if *self == 0 {
                     1
                 }
                 else {
@@ -112,11 +112,11 @@ macro_rules! unsigned_content {
             }
 
             fn write_encoded<W: io::Write>(
-                self,
+                &self,
                 _: Mode,
                 target: &mut W
             ) -> Result<(), io::Error> {
-                if self == 0 {
+                if *self == 0 {
                     target.write(&[0x00])?;
                 }
                 else {
@@ -153,16 +153,16 @@ unsigned_content!(u128, 16);
 impl PrimitiveContent for i8 {
     const TAG: Tag = Tag::INTEGER;
 
-    fn encoded_len(self, _: Mode) -> usize {
+    fn encoded_len(&self, _: Mode) -> usize {
         1
     }
 
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {
-        target.write(&[self as u8])?;
+        target.write(&[*self as u8])?;
         Ok(())
     }
 }
@@ -172,12 +172,12 @@ macro_rules! signed_content {
         impl PrimitiveContent for $type {
             const TAG: Tag = Tag::INTEGER;
 
-            fn encoded_len(self, _: Mode) -> usize {
-                if self == 0 || self == -1 {
+            fn encoded_len(&self, _: Mode) -> usize {
+                if *self == 0 || *self == -1 {
                     1
                 }
-                else if self < 0 {
-                    $len - (((!self).leading_zeros() as usize) >> 3)
+                else if *self < 0 {
+                    $len - (((!*self).leading_zeros() as usize) >> 3)
                 }
                 else {
                     $len - ((self.leading_zeros() as usize) >> 3)
@@ -185,17 +185,17 @@ macro_rules! signed_content {
             }
 
             fn write_encoded<W: io::Write>(
-                self,
+                &self,
                 _: Mode,
                 target: &mut W
             ) -> Result<(), io::Error> {
-                if self == 0 {
+                if *self == 0 {
                     target.write(&[0x00])?;
                 }
-                else if self == -1 {
+                else if *self == -1 {
                     target.write(&[0xFF])?;
                 }
-                else if self < 0 {
+                else if *self < 0 {
                     let mut val = self.swap_bytes();
                     let mut i = 0;
                     while i < $len {
@@ -242,12 +242,12 @@ signed_content!(i128, 16);
 impl PrimitiveContent for () {
     const TAG: Tag = Tag::NULL;
 
-    fn encoded_len(self, _: Mode) -> usize {
+    fn encoded_len(&self, _: Mode) -> usize {
         0
     }
 
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         _: Mode,
         _: &mut W
     ) -> Result<(), io::Error> {
@@ -258,16 +258,16 @@ impl PrimitiveContent for () {
 impl PrimitiveContent for bool {
     const TAG: Tag = Tag::BOOLEAN;
 
-    fn encoded_len(self, _: Mode) -> usize {
+    fn encoded_len(&self, _: Mode) -> usize {
         1
     }
 
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {
-        if self {
+        if *self {
             target.write_all(&[0xff])
         }
         else {
@@ -279,12 +279,12 @@ impl PrimitiveContent for bool {
 impl<'a> PrimitiveContent for &'a [u8] {
     const TAG: Tag = Tag::OCTET_STRING;
 
-    fn encoded_len(self, _: Mode) -> usize {
+    fn encoded_len(&self, _: Mode) -> usize {
         self.len()
     }
 
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {

--- a/src/encode/primitive.rs
+++ b/src/encode/primitive.rs
@@ -77,6 +77,24 @@ pub trait PrimitiveContent: Sized {
     }
 }
 
+//--- Blanket impls
+
+impl<'a, T: PrimitiveContent> PrimitiveContent for &'a T {
+    const TAG: Tag = T::TAG;
+
+    fn encoded_len(&self, mode: Mode) -> usize {
+        (*self).encoded_len(mode)
+    }
+
+    fn write_encoded<W: io::Write>(
+        &self,
+        mode: Mode,
+        target: &mut W
+    ) -> Result<(), io::Error> {
+        (*self).write_encoded(mode, target)
+    }
+}
+
 
 //--- impl for built-in types
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -361,12 +361,12 @@ impl hash::Hash for Integer {
 impl<'a> PrimitiveContent for &'a Integer {
     const TAG: Tag = Tag::INTEGER;
 
-    fn encoded_len(self, _mode: Mode) -> usize {
+    fn encoded_len(&self, _mode: Mode) -> usize {
         self.0.len()
     }
 
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         _mode: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {
@@ -540,16 +540,16 @@ impl AsRef<[u8]> for Unsigned {
 impl<'a> PrimitiveContent for &'a Unsigned {
     const TAG: Tag = Tag::INTEGER;
 
-    fn encoded_len(self, mode: Mode) -> usize {
-        self.0.encoded_len(mode)
+    fn encoded_len(&self, mode: Mode) -> usize {
+        (&self.0).encoded_len(mode)
     }
 
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         mode: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {
-        self.0.write_encoded(mode, target)
+        (&self.0).write_encoded(mode, target)
     }
 }
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -207,12 +207,12 @@ impl<T: AsRef<[u8]>> fmt::Display for Oid<T> {
 impl<'a, T: AsRef<[u8]>> encode::PrimitiveContent for &'a Oid<T> {
     const TAG: Tag = Tag::OID;
 
-    fn encoded_len(self, _: Mode) -> usize {
+    fn encoded_len(&self, _: Mode) -> usize {
         self.0.as_ref().len()
     }
 
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {

--- a/src/string/bit.rs
+++ b/src/string/bit.rs
@@ -188,6 +188,7 @@ impl BitString {
         }
     }
 
+    /*
     pub fn encode<'a>(&'a self) -> impl encode::Values + 'a {
         encode::PrimitiveContent::encode(self)
     }
@@ -195,6 +196,7 @@ impl BitString {
     pub fn encode_as<'a>(&'a self, tag: Tag) -> impl encode::Values + 'a {
         encode::PrimitiveContent::encode_as(self, tag)
     }
+    */
 }
 
 
@@ -203,12 +205,12 @@ impl BitString {
 impl<'a> encode::PrimitiveContent for &'a BitString {
     const TAG: Tag = Tag::BIT_STRING;
 
-    fn encoded_len(self, _: Mode) -> usize {
+    fn encoded_len(&self, _: Mode) -> usize {
         self.bits.len() + 1
     }
 
     fn write_encoded<W: io::Write>(
-        self,
+        &self,
         _: Mode,
         target: &mut W
     ) -> Result<(), io::Error> {

--- a/src/string/bit.rs
+++ b/src/string/bit.rs
@@ -202,7 +202,7 @@ impl BitString {
 
 //--- PrimitiveContent
 
-impl<'a> encode::PrimitiveContent for &'a BitString {
+impl encode::PrimitiveContent for BitString {
     const TAG: Tag = Tag::BIT_STRING;
 
     fn encoded_len(&self, _: Mode) -> usize {


### PR DESCRIPTION
This PR adjusts the #7 to have the encoding methods of `PrimitiveContent` to take self by reference but makes `encode` and `encode_as` move self to resulting `Primitive`. This way, you can move a primitively encoded value into a composite encoder if you want to.