### PR TITLE
Allow encode octet slices directly.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,9 @@ New
 
 *  `encode::Values` implemented for tuples of up to twelve elements.
    [(#9)]
+*  `OctetString::encode_slice` and `encode_slice_as`: allows encoding a bytes
+   slice as an octet string without going through making an `OctetString`
+   first.
 
 Bug Fixes
 
@@ -18,6 +21,7 @@ Dependencies
 
 [(#7)]: https://github.com/NLnetLabs/bcder/pull/7
 [(#9)]: https://github.com/NLnetLabs/bcder/pull/9
+[(#10)]: https://github.com/NLnetLabs/bcder/pull/10
 
 
 ## 0.1.0


### PR DESCRIPTION
This PR adds the functions `OctetString::encode_slice` and `OctetString::encode_slice_as` which make it possible to encode a bytes slice as an OCTET STRING without first turning it into a `Bytes` object.