### PR TITLE
Fix encoding of primitive unsigned integers.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,13 @@ New
 
 Bug Fixes
 
+*  Fix incorrect encoding of primitive unsigned integers for values with a
+   number of leading zero bits divisible by eight. [(#16)]
+
 Dependencies
+
+
+[(#16)]: https://github.com/NLnetLabs/rpki-rs/pull/16
 
 
 ## 0.2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,10 @@
 //! [`Captured`]: captured/struct.Captured.html
 #![allow(renamed_and_removed_lints, unknown_lints)]
 
+// We have seemingly redundant closures (i.e., closures where just providing
+// a function would also work) that cannot be removed due to lifetime issues.
+#![allow(redundant_closure)]
+
 extern crate bytes;
 #[macro_use] extern crate derive_more;
 


### PR DESCRIPTION
The previous code would only check the most significant bit when considering whether to add an extra zero. What it needs to do, though, is check the most significant bit of the first byte to actually be written since BER encoded integers are variable length.

This PR fixes this this check.