### PR TITLE
Allow safe decoding of nested values.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ license = "BSD-3-Clause"
 backtrace   = { version = "^0.3.15", optional = true }
 bytes       = "^0.4"
 derive_more = "^0.15"
+smallvec    = "^0.6.10"
+unwrap      = "^1.2.1"
 
 [features]
 # Print a backtrace when a parsing error occurs. This feature is intended for

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,8 +8,14 @@ New
 
 Bug Fixes
 
+* Safely decode deeply nested BER such as octet strings. Decoding such
+  types now uses an allocated artifical stack and will thus not overflow
+  the regular one anymore. [(#30)]
+
 Dependencies
 
+
+[(#30)]: https://github.com/NLnetLabs/bcder/pull/30
 
 ## 0.3.1
 

--- a/src/decode/content.rs
+++ b/src/decode/content.rs
@@ -1065,7 +1065,7 @@ impl<'a, S: Source + 'a> Constructed<'a, S> {
     pub fn skip<F>(&mut self, op: F) -> Result<(), S::Err>
     where F: FnMut(Tag, bool, usize) -> Result<(), S::Err> {
         if self.skip_opt(op)? == None {
-            xerr!(return Err(Error::Malformed.into()));
+            xerr!(Err(Error::Malformed.into()))
         }
         else {
             Ok(())

--- a/src/decode/content.rs
+++ b/src/decode/content.rs
@@ -963,11 +963,9 @@ impl<'a, S: Source + 'a> Constructed<'a, S> {
         let mut stack = SmallVec::<[Option<Option<usize>>; 4]>::new();
 
         loop {
-            dbg!(&stack);
             // Get a the ‘header’ of a value.
             let (tag, constructed) = Tag::take_from(self.source)?;
             let length = Length::take_from(self.source, self.mode)?;
-            dbg!(tag, constructed, length);
 
             if !constructed {
                 if tag == Tag::END_OF_VALUE {
@@ -1056,7 +1054,6 @@ impl<'a, S: Source + 'a> Constructed<'a, S> {
                 self.source.set_limit(Some(len));
             }
             else {
-                dbg!();
                 // Indefinite constructed value. Simply push a `None` to the
                 // stack, if the caller likes it.
                 op(tag, constructed, stack.len())?;

--- a/src/decode/error.rs
+++ b/src/decode/error.rs
@@ -3,6 +3,8 @@
 //! This is a private module. Its public content is being re-exported by the
 //! parent module.
 
+use derive_more::Display;
+
 
 //------------ Error ---------------------------------------------------------
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -16,6 +16,7 @@
 use std::{cmp, hash, io, mem};
 use std::convert::TryFrom;
 use bytes::Bytes;
+use derive_more::Display;
 use crate::decode;
 use crate::decode::Source;
 use crate::encode::PrimitiveContent;

--- a/src/length.rs
+++ b/src/length.rs
@@ -17,7 +17,7 @@ use crate::mode::Mode;
 ///
 /// # BER Encoding
 ///
-/// The length can be encoded in one of two basic ways. Which is used is
+/// The length can be encoded in one of two basic ways. Which one is used is
 /// determined by the most significant bit of the first octet. If it is not
 /// set, the length octets is one octet long and the remaining bits of this
 /// first octet provide the definite length. Thus, if the first octet is
@@ -30,14 +30,13 @@ use crate::mode::Mode;
 /// those following octets give the big-endian encoding of the definite
 /// length of the content octets.
 ///
-/// Under both CER and DER rules, a definite length must be encded in the
+/// Under both CER and DER rules, a definite length must be encoded in the
 /// minimum number of octets.
 ///
 /// # Limitation
 ///
-/// The current implementation is limited to 32 bits for an encoded definite
-/// length. This is true even on 64 bit platforms where the `usize` can hold
-/// more bits.
+/// The current implementation is limited to 4 length bytes on 32 bit systems
+/// and 5 length bytes on 64 bit sytems.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Length {
     /// A length value in definite form.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,6 @@
 // a function would also work) that cannot be removed due to lifetime issues.
 #![allow(redundant_closure)]
 
-extern crate bytes;
-#[macro_use] extern crate derive_more;
-
 //--- Re-exports
 
 pub use self::captured::Captured;

--- a/src/string/octet.rs
+++ b/src/string/octet.rs
@@ -217,7 +217,7 @@ impl OctetString {
                 else {
                     xerr!(Err(decode::Malformed.into()))
                 }
-            })? == Some(()) { }
+            })?.is_some() { }
             Ok(())
         }).map(|captured| OctetString(Inner::Constructed(captured)))
     }
@@ -903,6 +903,21 @@ mod tests {
             unwrap!(decode::Constructed::decode(
                 b"\x24\x08\
                 \x24\x80\
+                \x04\x02ab\
+                \0\0".as_ref(),
+                Mode::Ber,
+                |cons| {
+                    OctetString::take_from(cons)
+                }
+            )).to_bytes(),
+            "ab"
+        );
+
+        println!("lllllll");
+        // I(p)
+        assert_eq!(
+            unwrap!(decode::Constructed::decode(
+                b"\x24\x80\
                 \x04\x02ab\
                 \0\0".as_ref(),
                 Mode::Ber,

--- a/src/string/octet.rs
+++ b/src/string/octet.rs
@@ -207,10 +207,19 @@ impl OctetString {
     ///
     /// It consists octet string values either primitive or constructed.
     fn take_constructed_ber<S: decode::Source>(
-        constructed: &mut decode::Constructed<S>
+        cons: &mut decode::Constructed<S>
     ) -> Result<Self, S::Err> {
-        constructed.capture(|constructed| skip_nested(constructed))
-            .map(|captured| OctetString(Inner::Constructed(captured)))
+        cons.capture(|cons| {
+            while cons.skip_opt(|tag, _, _| {
+                if tag == Tag::OCTET_STRING {
+                    Ok(())
+                }
+                else {
+                    xerr!(Err(decode::Malformed.into()))
+                }
+            })? == Some(()) { }
+            Ok(())
+        }).map(|captured| OctetString(Inner::Constructed(captured)))
     }
 
     /// Parses a constructed CER encoded octet string.
@@ -848,34 +857,81 @@ impl<V: encode::Values> encode::Values for WrappingOctetStringEncoder<V> {
 }
 
 
-//------------ Helper Functions ----------------------------------------------
-
-fn skip_nested<S>(con: &mut decode::Constructed<S>) -> Result<(), S::Err>
-where S: decode::Source {
-    while let Some(()) = con.take_opt_value_if(Tag::OCTET_STRING, |content| {
-        match content {
-            decode::Content::Constructed(ref mut inner) => {
-                skip_nested(inner)?
-            }
-            decode::Content::Primitive(ref mut inner) => {
-                inner.skip_all()?
-            }
-        }
-        Ok(())
-    })? { }
-    Ok(())
-}
-
-
 //------------ Tests ---------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
+    use unwrap::unwrap;
+    use crate::encode::{Values, PrimitiveContent};
     use super::*;
-    use encode::{Values, PrimitiveContent};
 
     #[test]
-    fn should_wrap_content_in_octetstring() {
+    fn take_from_ber() {
+        // D .. definite constructed
+        // I .. indefinied constructed
+        // p .. primitive
+
+        // D(p)
+        assert_eq!(
+            unwrap!(decode::Constructed::decode(
+                b"\x24\x04\
+                \x04\x02ab".as_ref(),
+                Mode::Ber,
+                |cons| {
+                    OctetString::take_from(cons)
+                }
+            )).to_bytes(),
+            "ab"
+        );
+
+        // D(pp)
+        assert_eq!(
+            unwrap!(decode::Constructed::decode(
+                b"\x24\x06\
+                \x04\x01a\
+                \x04\x01b".as_ref(),
+                Mode::Ber,
+                |cons| {
+                    OctetString::take_from(cons)
+                }
+            )).to_bytes(),
+            "ab"
+        );
+
+        // D(I(p))
+        assert_eq!(
+            unwrap!(decode::Constructed::decode(
+                b"\x24\x08\
+                \x24\x80\
+                \x04\x02ab\
+                \0\0".as_ref(),
+                Mode::Ber,
+                |cons| {
+                    OctetString::take_from(cons)
+                }
+            )).to_bytes(),
+            "ab"
+        );
+
+        // D(pI(p))
+        assert_eq!(
+            unwrap!(decode::Constructed::decode(
+                b"\x24\x0a\
+                \x04\x01a\
+                \x24\x80\
+                \x04\x01b\
+                \0\0".as_ref(),
+                Mode::Ber,
+                |cons| {
+                    OctetString::take_from(cons)
+                }
+            )).to_bytes(),
+            "ab"
+        );
+    }
+
+    #[test]
+    fn encode_wrapped() {
         let mut v = Vec::new();
         let enc = OctetString::encode_wrapped(Mode::Der, true.encode());
         enc.write_encoded(Mode::Der, &mut v).unwrap();


### PR DESCRIPTION
Fixes #5.