### PR TITLE
Remove derive_more dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ license = "BSD-3-Clause"
 [dependencies]
 backtrace   = { version = "^0.3.15", optional = true }
 bytes       = "^0.4"
-derive_more = "^0.15"
 smallvec    = "^0.6.10"
 unwrap      = "^1.2.1"
 

--- a/src/decode/error.rs
+++ b/src/decode/error.rs
@@ -3,20 +3,26 @@
 //! This is a private module. Its public content is being re-exported by the
 //! parent module.
 
-use derive_more::Display;
+use std::fmt;
 
 
 //------------ Error ---------------------------------------------------------
 
 /// An error happened while decoding data.
-#[derive(Clone, Copy, Debug, Display, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
     /// The data didn’t conform to the expected structure.
-    #[display(fmt="malformed data")]
     Malformed,
 
     /// An encoding used by the data is not yet implemented by the crate.
-    #[display(fmt="format not implemented")]
     Unimplemented,
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Malformed => write!(f, "malformed data"),
+            Error::Unimplemented => write!(f, "format not implemented"),
+        }
+    }
+}

--- a/src/int.rs
+++ b/src/int.rs
@@ -13,10 +13,9 @@
 //! [`Integer`]: struct.Integer.html
 //! [`Unsigned`]: struct.Unsigned.html
 
-use std::{cmp, hash, io, mem};
+use std::{cmp, fmt, hash, io, mem};
 use std::convert::TryFrom;
 use bytes::Bytes;
-use derive_more::Display;
 use crate::decode;
 use crate::decode::Source;
 use crate::encode::PrimitiveContent;
@@ -635,9 +634,14 @@ impl<'a> PrimitiveContent for &'a Unsigned {
 
 //------------ OverflowError -------------------------------------------------
 
-#[derive(Clone, Copy, Debug, Display)]
-#[display(fmt="integer out of range")]
+#[derive(Clone, Copy, Debug)]
 pub struct OverflowError(());
+
+impl fmt::Display for OverflowError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "integer out of range")
+    }
+}
 
 
 //============ Tests =========================================================


### PR DESCRIPTION
I noticed `derive_more` was only being used in two places to derive `Display`, so I manually implemented `Display` in those cases. 

This improved compile time quite a bit, with virtually no change in compiled size

`cargo build --release`:

|Platform|Before|After|
|---------|--------|-----|
|Windows|54s|29s|
|Linux (WSL)|37s (29 crates)|5.6s (12 crates)|

Windows still takes a while since it needs `winapi` from `bytes`