### PR TITLE
Fix bug in tag length request

### DIFF
--- a/src/tag.rs
+++ b/src/tag.rs
@@ -378,7 +378,7 @@ impl Tag {
         if (data[0] & Tag::SINGLEBYTE_DATA_MASK) == Tag::SINGLEBYTE_DATA_MASK {
             let mut i = 1;
             loop {
-                if source.request(i+1)? == 0 {
+                if source.request(i+1)? <= i {
                     // TODO: Should we return an error instead?
                     return Ok(None)
                 }


### PR DESCRIPTION
There is a bug that stemmed from a lack of understanding on my part of how request work. 
After some run failures I see now that it returns how much data is available to read.. 