### PR TITLE
Move extending a Captured into a CapturedBuilder.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcder"
-version = "0.4.3-pre"
+version = "0.5.0-pre"
 edition = "2018"
 authors = ["The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"]
 description = "Handling of data encoded in BER, CER, and DER."

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,11 +4,16 @@
 
 Breaking
 
+* Move extending a `Captured` to an explicit `CapturedBuilder`. This
+  becomes necessary with bytes 0.5. [(#46)]
+
 New
 
 Bug Fixes
 
 Dependencies
+
+[(#46)]: https://github.com/NLnetLabs/bcder/pull/46
 
 
 ## 0.4.2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 
 //--- Re-exports
 
-pub use self::captured::Captured;
+pub use self::captured::{Captured, CapturedBuilder};
 pub use self::int::{Integer, Unsigned};
 pub use self::mode::Mode;
 pub use self::oid::{ConstOid, Oid};


### PR DESCRIPTION
This is the first part of moving to bytes 0.5. See #42 and #43 as well.