### PR TITLE
Expose Captured::new publicly

### DIFF
--- a/src/captured.rs
+++ b/src/captured.rs
@@ -52,11 +52,7 @@ pub struct Captured {
 
 impl Captured {
     /// Creates a new captured value from bytes and a mode.
-    ///
-    /// Because we can’t guarantee that the bytes are properly encoded, we
-    /// keep this function crate public. The type, however, doesn’t rely on
-    /// content being properly encoded so this method isn’t unsafe.
-    pub(crate) fn new(bytes: Bytes, mode: Mode, start: Pos) -> Self {
+    pub fn new(bytes: Bytes, mode: Mode, start: Pos) -> Self {
         Captured { bytes, mode, start }
     }
 


### PR DESCRIPTION
I believe this particular function should be public.  I have a use case where I have opaque DER encoded data that I must store during decoding and emitted during encoding.  `Captured` is the perfect type for this, however, since the source data is opaque, I have no way to construct a `Captured`.  The closest method is to decode it as a `Constructed`, but that only works when the opaque data is constructed, and not primitive

Since `Captured` can be constructed without using unsafe, it should be alright to expose this.  `Captured` can no longer assume it contains valid data, though