### PR TITLE
Added FromStr implementation for Oid

### DIFF
--- a/src/bin/mkoid.rs
+++ b/src/bin/mkoid.rs
@@ -7,53 +7,14 @@
 //! you will receive the octet array for it.
 
 use std::env;
-use std::str::FromStr;
-
-fn from_str(s: &str) -> Result<u32, &'static str> {
-    u32::from_str(s).map_err(|_| "only integer components allowed")
-}
+use bcder::Oid;
 
 fn process_one(arg: &str) -> Result<(), &'static str> {
-    let mut components = arg.split('.');
-    let (first, second) = match (components.next(), components.next()) {
-        (Some(first), Some(second)) => (first, second),
-        _ => {
-            return Err("at least two components required");
-        }
-    };
-    let first = from_str(first)?;
-    if first > 2 {
-        return Err("first component can only be 0, 1, or 2.")
-    }
-    let second = from_str(second)?;
-    if first < 2 && second >= 40 {
-        return Err("second component for 0. and 1. must be less than 40");
-    }
-    let mut res = vec![40 * first + second];
-    for item in components {
-        res.push(from_str(item)?);
-    }
+    let oid_bytes = arg.parse::<Oid<Vec<u8>>>()?.0;
 
-    let mut first = true;
     print!("[");
-    for item in res {
-        if !first { print!(", "); }
-        else { first = false }
-        // 1111 1111  1111 1111  1111 1111  1111 1111
-        // EEEE DDDD  DDDC CCCC  CCBB BBBB  BAAA AAAA
-        if item > 0x0FFF_FFFF {
-            print!("{}, ", (item >> 28) | 0x80)
-        }
-        if item > 0x001F_FFFF {
-            print!("{}, ", ((item >> 21) & 0x7F) | 0x80)
-        }
-        if item > 0x0000_3FFF {
-            print!("{}, ", ((item >> 14) & 0x7F) | 0x80)
-        }
-        if item > 0x0000_007F {
-            print!("{}, ", ((item >> 7) & 0x7F) | 0x80)
-        }
-        print!("{}", item & 0x7F);
+    for byte in oid_bytes { // rust doesn't mind an extra trailing comma
+        print!("{},", byte);
     }
     println!("]");
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -6,7 +6,7 @@
 //!
 //! [`Oid`]: struct.Oid.html
 
-use std::{fmt, hash, io};
+use std::{fmt, hash, io, str::FromStr};
 use bytes::Bytes;
 use crate::encode;
 use crate::decode::{Constructed, DecodeError, Source};
@@ -206,6 +206,61 @@ impl<T: AsRef<[u8]>> encode::PrimitiveContent for Oid<T> {
         target: &mut W
     ) -> Result<(), io::Error> {
         target.write_all(self.0.as_ref())
+    }
+}
+
+
+//--- FromStr
+
+impl<T: AsRef<[u8]> + From<Vec<u8>>> FromStr for Oid<T> {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        fn from_str(s: &str) -> Result<u32, &'static str> {
+            u32::from_str(s).map_err(|_| "only integer components allowed")
+        }
+
+        let mut components = s.split('.');
+        let (first, second) = match (components.next(), components.next()) {
+            (Some(first), Some(second)) => (first, second),
+            _ => { return Err("at least two components required"); }
+        };
+
+        let first = from_str(first)?;
+        if first > 2 {
+            return Err("first component can only be 0, 1, or 2.")
+        }
+
+        let second = from_str(second)?;
+        if first < 2 && second >= 40 {
+            return Err("second component for 0. and 1. must be less than 40");
+        }
+
+        let mut res = vec![40 * first + second];
+        for item in components {
+            res.push(from_str(item)?);
+        }
+
+        let mut bytes = vec![];
+        for item in res {
+            // 1111 1111  1111 1111  1111 1111  1111 1111
+            // EEEE DDDD  DDDC CCCC  CCBB BBBB  BAAA AAAA
+            if item > 0x0FFF_FFFF {
+                bytes.push(((item >> 28) | 0x80) as u8);
+            }
+            if item > 0x001F_FFFF {
+                bytes.push((((item >> 21) & 0x7F) | 0x80) as u8);
+            }
+            if item > 0x0000_3FFF {
+                bytes.push((((item >> 14) & 0x7F) | 0x80) as u8)
+            }
+            if item > 0x0000_007F {
+                bytes.push((((item >> 7) & 0x7F) | 0x80) as u8);
+            }
+            bytes.push((item & 0x7F) as u8);
+        }
+
+        Ok(Oid(bytes.into()))
     }
 }
 


### PR DESCRIPTION
As discussed previously, adding a `FromStr` implementation for `Oid`.  Implementation is only valid for types that can be converted from `Vec<u8>` (which includes `Bytes`).  Should work for custom byte containers, so long as they provide a converter from `Vec<u8>`

`mkoid` will output one comma too many, but `rustc` doesn't actually care about an extra trailing comma.