### PR TITLE
Bump smallvec version because of security advisory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ license = "BSD-3-Clause"
 
 [dependencies]
 bytes       = "^1.0"
-smallvec    = "^1.1"
+smallvec    = "^1.6.1"
 


### PR DESCRIPTION
This PR bumps the smallvec dependency to version 1.6.1, as recommended in https://rustsec.org/advisories/RUSTSEC-2021-0003 .