### PR TITLE
Avoid certain panics in decoding.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
-    - if: matrix.rust != 'nightly'
+    - if: matrix.rust == 'stable'
       run: rustup component add clippy
-    - if: matrix.rust != 'nightly'
+    - if: matrix.rust == 'stable'
       run: cargo clippy --all --all-features -- -D warnings
     - run: cargo build --verbose --all --all-features
     - run: cargo test --verbose --all --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.64.0, stable, beta, nightly]
+        rust: [1.74.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bcder"
 version = "0.8.0-dev"
 edition = "2018"
+rust-version = "1.74"
 authors = ["NLnet Labs <rust-team@nlnetlabs.nl>"]
 description = "Handling of data encoded in BER, CER, and DER."
 documentation = "https://docs.rs/bcder/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcder"
-version = "0.7.6-dev"
+version = "0.8.0-dev"
 edition = "2018"
 authors = ["NLnet Labs <rust-team@nlnetlabs.nl>"]
 description = "Handling of data encoded in BER, CER, and DER."

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+allow-indexing-slicing-in-tests = true
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/src/captured.rs
+++ b/src/captured.rs
@@ -243,6 +243,7 @@ impl CapturedBuilder {
     ///
     /// The function encodes the given values in the captured value’s own mode
     /// and places the encoded content at the end of the captured value.
+    #[allow(clippy::unwrap_used)] // XXX Allow temporarly, fix in separate PR.
     pub fn extend<V: encode::Values>(&mut self, values: V) {
         values.write_encoded(
             self.mode,

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -28,6 +28,9 @@
 //! [`PrimitiveContent`]: trait.PrimitiveContent.html
 //! [encode section of the guide]: ../guide/encode/index.html
 
+// XXX Allow temporarily, will be fixed in separate PR.
+#![allow(clippy::unwrap_used)]
+
 pub use self::primitive::{PrimitiveContent, Primitive};
 pub use self::values::{
     Values,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 // We have seemingly redundant closures (i.e., closures where just providing
 // a function would also work) that cannot be removed due to lifetime issues.
 #![allow(clippy::redundant_closure)]
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 
 
 //--- Re-exports

--- a/src/string/bit.rs
+++ b/src/string/bit.rs
@@ -2,6 +2,9 @@
 //!
 //! This is a private module. Its public items are re-exported by the parent.
 
+// XXX This module needs some redesigning.
+#![allow(clippy::indexing_slicing)]
+
 use std::io;
 use bytes::Bytes;
 use crate::{decode, encode};

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -227,14 +227,14 @@ impl Tag {
     ///
     /// There are two forms:
     /// * low tag number (for tag numbers between 0 and 30):
-    ///     One octet. Bits 8 and 7 specify the class, bit 6 indicates whether
-    ///     the encoding is primitive (0), and bits 5-1 give the tag number.
+    ///   One octet. Bits 8 and 7 specify the class, bit 6 indicates whether
+    ///   the encoding is primitive (0), and bits 5-1 give the tag number.
     /// * high tag number (for tag numbers 31 and greater):
-    ///     Two or more octets. First octet is as in low-tag-number form,
-    ///     except that bits 5-1 all have value 1. Second and following octets
-    ///     give the tag number, base 128, most significant digit first, with
-    ///     as few digits as possible, and with the bit 8 of each octet except
-    ///     the last set to 1.
+    ///   Two or more octets. First octet is as in low-tag-number form,
+    ///   except that bits 5-1 all have value 1. Second and following octets
+    ///   give the tag number, base 128, most significant digit first, with
+    ///   as few digits as possible, and with the bit 8 of each octet except
+    ///   the last set to 1.
     //
     /// # Panics
     ///

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -492,10 +492,7 @@ impl Tag {
         target.write_all(
             // XXX Maybe redesign internal storage to avoid this error?
             buf.get(..self.encoded_len()).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    "bug: encountered overly long tag"
-                )
+                io::Error::other("bug: encountered overly long tag")
             })?
         )
     }


### PR DESCRIPTION
This PR changes most of the decoding code to be mostly panic free.

Specifically, it removes the use of slice indexing as well as `unwrap` and `expect` on options and results.

It does not do this for encoding – which requires some redesign in the traits – and for the string types – which will be done in separate PRs to make reviewing of this PR easier.

The PR introduces a breaking change in the `decode::Source` trait by changing how invalid indexes are treated. The `bytes` method now returns an optional `Bytes`, returning `None` if the indexes are invalid. If the `advance` method is called with an invalid length, the source is expected to go into some error state. Finally, the error type of `take_opt_u8` was changed to allow an explicit error.

This PR raises the minimum supported Rust version to 1.74.