### PR TITLE
Add separate method for encoding to `Vec<u8>`.

### DIFF
--- a/src/captured.rs
+++ b/src/captured.rs
@@ -198,6 +198,14 @@ impl encode::Values for Captured {
         );
         target.write_all(self.bytes.as_ref())
     }
+
+    fn append_encoded(&self, mode: Mode, target: &mut Vec<u8>) {
+        assert!(
+            !(self.mode != mode && mode != Mode::Ber),
+            "Trying to encode a captured value with incompatible mode"
+        );
+        target.extend_from_slice(self.bytes.as_ref())
+    }
 }
 
 

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -32,8 +32,8 @@ pub use self::primitive::{PrimitiveContent, Primitive};
 pub use self::values::{
     Values,
     Choice2, Choice3, Constructed, Iter, Nothing, Slice,
-    iter, sequence, sequence_as, set, set_as, slice, total_encoded_len,
-    write_header,
+    append_header, iter, sequence, sequence_as, set, set_as, slice,
+    total_encoded_len, write_header,
 };
 
 mod primitive;

--- a/src/int.rs
+++ b/src/int.rs
@@ -411,6 +411,10 @@ impl PrimitiveContent for &'_ Integer {
     ) -> Result<(), io::Error> {
         target.write_all(self.0.as_ref())
     }
+
+    fn append_encoded(&self, _mode: Mode, target: &mut Vec<u8>) {
+        target.extend_from_slice(self.0.as_ref())
+    }
 }
 
 
@@ -667,6 +671,10 @@ impl PrimitiveContent for &'_ Unsigned {
         target: &mut W
     ) -> Result<(), io::Error> {
         (&self.0).write_encoded(mode, target)
+    }
+
+    fn append_encoded(&self, mode: Mode, target: &mut Vec<u8>) {
+        (&self.0).append_encoded(mode, target)
     }
 }
 

--- a/src/length.rs
+++ b/src/length.rs
@@ -245,4 +245,77 @@ impl Length {
             }
         }
     }
+
+    /// Writes the encoded value to a target.
+    #[cfg(target_pointer_width = "64")]
+    pub fn append_encoded(&self, target: &mut Vec<u8>) {
+        match *self {
+            Length::Indefinite => {
+                target.push(0x80)
+            }
+            Length::Definite(len) => {
+                if len < 0x80 {
+                    target.push(len as u8);
+                }
+                else if len < 0x1_00 {
+                    target.push(0x81);
+                    target.push(len as u8);
+                }
+                else if len < 0x1_0000 {
+                    target.push(0x82);
+                    target.push((len >> 8) as u8);
+                    target.push(len as u8);
+                }
+                else if len < 0x100_0000 {
+                    target.push(0x83);
+                    target.push((len >> 16) as u8);
+                    target.push((len >> 8) as u8);
+                    target.push(len as u8);
+                }
+                else if len < 0x1_0000_0000 {
+                    target.push(0x84);
+                    target.push((len >> 24) as u8);
+                    target.push((len >> 16) as u8);
+                    target.push((len >> 8) as u8);
+                    target.push(len as u8);
+                }
+                else {
+                    panic!("excessive length")
+                }
+            }
+        }
+    }
+
+    /// Writes the encoded value to a target.
+    #[cfg(not(target_pointer_width = "64"))]
+    pub fn append_encoded(&self, target: &mut Vec<u8>) {
+        match *self {
+            Length::Indefinite => {
+                target.push(0x80)
+            }
+            Length::Definite(len) => {
+                if len < 0x80 {
+                    target.push(len as u8);
+                }
+                else if len < 0x1_00 {
+                    target.push(0x81);
+                    target.push(len as u8);
+                }
+                else if len < 0x1_0000 {
+                    target.push(0x82);
+                    target.push((len >> 8) as u8);
+                    target.push(len as u8);
+                }
+                else if len < 0x100_0000 {
+                    target.push(0x83);
+                    target.push((len >> 16) as u8);
+                    target.push((len >> 8) as u8);
+                    target.push(len as u8);
+                }
+                else {
+                    panic!("excessive length")
+                }
+            }
+        }
+    }
 }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -240,6 +240,10 @@ impl<T: AsRef<[u8]>> encode::PrimitiveContent for Oid<T> {
     ) -> Result<(), io::Error> {
         target.write_all(self.0.as_ref())
     }
+
+    fn append_encoded(&self, _mode: Mode, target: &mut Vec<u8>) {
+        target.extend_from_slice(self.0.as_ref())
+    }
 }
 
 

--- a/src/string/bit.rs
+++ b/src/string/bit.rs
@@ -266,6 +266,11 @@ impl encode::PrimitiveContent for BitString {
         target.write_all(&[self.unused])?;
         target.write_all(self.bits.as_ref())
     }
+
+    fn append_encoded(&self, _mode: Mode, target: &mut Vec<u8>) {
+        target.push(self.unused);
+        target.extend_from_slice(self.bits.as_ref());
+    }
 }
 
 
@@ -330,6 +335,18 @@ impl<T: AsRef<[u8]>> encode::Values for BitSliceEncoder<T> {
         Length::Definite(self.slice.as_ref().len() + 1).write_encoded(target)?;
         target.write_all(&[self.unused])?;
         target.write_all(self.slice.as_ref())
+    }
+
+    fn append_encoded(&self, mode: Mode, target: &mut Vec<u8>) {
+        if mode == Mode::Cer {
+            unimplemented!()
+        }
+        self.tag.append_encoded(false, target);
+        Length::Definite(
+            self.slice.as_ref().len() + 1
+        ).append_encoded(target);
+        target.push(self.unused);
+        target.extend_from_slice(self.slice.as_ref())
     }
 }
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -227,14 +227,14 @@ impl Tag {
     ///
     /// There are two forms:
     /// * low tag number (for tag numbers between 0 and 30):
-    ///     One octet. Bits 8 and 7 specify the class, bit 6 indicates whether
-    ///     the encoding is primitive (0), and bits 5-1 give the tag number.
+    ///   One octet. Bits 8 and 7 specify the class, bit 6 indicates whether
+    ///   the encoding is primitive (0), and bits 5-1 give the tag number.
     /// * high tag number (for tag numbers 31 and greater):
-    ///     Two or more octets. First octet is as in low-tag-number form,
-    ///     except that bits 5-1 all have value 1. Second and following octets
-    ///     give the tag number, base 128, most significant digit first, with
-    ///     as few digits as possible, and with the bit 8 of each octet except
-    ///     the last set to 1.
+    ///   Two or more octets. First octet is as in low-tag-number form,
+    ///   except that bits 5-1 all have value 1. Second and following octets
+    ///   give the tag number, base 128, most significant digit first, with
+    ///   as few digits as possible, and with the bit 8 of each octet except
+    ///   the last set to 1.
     //
     /// # Panics
     ///
@@ -481,6 +481,15 @@ impl Tag {
             buf[0] |= Tag::CONSTRUCTED_MASK
         }
         target.write_all(&buf[..self.encoded_len()])
+    }
+
+    /// Appends the tag to a vec.
+    pub fn append_encoded(&self, constructed: bool, target: &mut Vec<u8>) {
+        let mut buf = self.0;
+        if constructed {
+            buf[0] |= Tag::CONSTRUCTED_MASK
+        }
+        target.extend_from_slice(&buf[..self.encoded_len()]);
     }
 }
 


### PR DESCRIPTION
This PR adds a new methods `Values::append_encoded` and `PrimitiveContent::append_encoded` that append the content to a `Vec<u8>` without returning a `Result<(), io::Error>`. This results in a bit of code duplication but avoids the use of `unwrap`s in case where a value is assembled in memory which is the most common use case.

This PR simply copies how `Tag` and `Length` are being encoded. They will be re-written in a follow-up PR.