### PR TITLE
Redesign decoding.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bcder"
 version = "0.7.6-dev"
-edition = "2018"
+edition = "2021"
 authors = ["NLnet Labs <rust-team@nlnetlabs.nl>"]
 description = "Handling of data encoded in BER, CER, and DER."
 documentation = "https://docs.rs/bcder/"

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -1,51 +1,12 @@
-//! Parsing BER-encoded data.
-//!
-//! This modules provides the means to parse BER-encoded data.
-//!
-//! The basic idea is that for each type a function exists that knows how
-//! to decode one value of that type. For constructed types, this function
-//! in turn relies on similar functions provided for its constituent types.
-//! For a detailed introduction to how to write these functions, please
-//! refer to the [decode section of the guide][crate::guide::decode].
-//!
-//! The two most important types of this module are [`Primitive`] and
-//! [`Constructed`], representing the content octets of a value in primitive
-//! and constructed encoding, respectively. Each provides a number of methods
-//! allowing to parse the content.
-//!
-//! You will never create a value of either type. Rather, you get handed a
-//! reference to one as an argument to a closure or function argument to be
-//! provided to these methods. 
-//!
-//! The enum [`Content`] is used for cases where a value can be either
-//! primitive or constructed such as most string types.
-//!
-//! The data for decoding is provided by any type that implements the
-//! [`Source`] trait – or can be converted into such a type via the
-//! [`IntoSource`] trait. Implementations for both `bytes::Bytes` and
-//! `&[u8]` are available.
-//!
-//! During decoding, errors can happen. There are two kinds of errors: for
-//! one, the source can fail to gather more data, e.g., when reading from a
-//! file fails. Such errors are called _source errors._ Their type is
-//! provided by the source.
-//!
-//! Second, data that cannot be decoded according to the syntax is said to
-//! result in a _content error._ The [`ContentError`] type is used for such
-//! errors.
-//!
-//! When decoding data from a source, both errors can happen. The type
-//! `DecodeError` provides a way to store either of them and is the error
-//! type you will likely encounter the most.
-
-pub use self::content::{Content, Constructed, Primitive};
+//pub use self::content::{Content, Constructed, Primitive};
 pub use self::error::{ContentError, DecodeError};
 pub use self::source::{
-    BytesSource, CaptureSource, IntoSource, Pos, LimitedSource, SliceSource,
+    Fragment, Pos, ReaderFragment, ReaderSource, SliceFragment, SliceSource,
     Source
 };
 
-mod content;
-mod error;
-mod source;
+
+pub mod content;
+pub mod error;
+pub mod source;
 

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -1,8 +1,48 @@
-//pub use self::content::{Content, Constructed, Primitive};
+//! Parsing BER-encoded data.
+//!
+//! This modules provides the means to parse BER-encoded data.
+//!
+//! The basic idea is that for each type a function exists that knows how
+//! to decode one value of that type. For constructed types, this function
+//! in turn relies on similar functions provided for its constituent types.
+//! For a detailed introduction to how to write these functions, please
+//! refer to the [decode section of the guide][crate::guide::decode].
+//!
+//! The two most important types of this module are [`Primitive`] and
+//! [`Constructed`], representing the content octets of a value in primitive
+//! and constructed encoding, respectively. Each provides a number of methods
+//! allowing to parse the content.
+//!
+//! You will never create a value of either type. Rather, you get handed a
+//! reference to one as an argument to a closure or function argument to be
+//! provided to these methods. 
+//!
+//! The enum [`Content`] is used for cases where a value can be either
+//! primitive or constructed such as most string types.
+//!
+//! The data for decoding is provided by any type that implements the
+//! [`Source`] trait – or can be converted into such a type via the
+//! [`IntoSource`] trait. Source implementations are currently available
+//! for byte slices and IO readers.
+//!
+//! During decoding, errors can happen. There are two kinds of errors: for
+//! one, the source can fail to gather more data, e.g., when reading from a
+//! file fails. Such errors are called _source errors._ Their type is
+//! provided by the source.
+//!
+//! Second, data that cannot be decoded according to the syntax is said to
+//! result in a _content error._ The [`ContentError`] type is used for such
+//! errors.
+//!
+//! When decoding data from a source, both errors can happen. The type
+//! `DecodeError` provides a way to store either of them and is the error
+//! type you will likely encounter the most.
+
+pub use self::content::{Content, Constructed, Primitive};
 pub use self::error::{ContentError, DecodeError};
 pub use self::source::{
-    Fragment, Pos, ReaderFragment, ReaderSource, SliceFragment, SliceSource,
-    Source
+    BorrowedFragment, Fragment, IntoSource, Pos, ReaderFragment, ReaderSource,
+    SliceFragment, SliceSource, Source,
 };
 
 

--- a/src/decode/source.rs
+++ b/src/decode/source.rs
@@ -1,118 +1,57 @@
-//! The source for decoding data.
-//!
-//! This is an internal module. Its public types are re-exported by the
-//! parent.
+/// 
 
-use std::{error, fmt, mem, ops};
-use std::cmp::min;
+use std::{error, fmt, io, ops};
 use std::convert::Infallible;
-use bytes::Bytes;
 use super::error::{ContentError, DecodeError};
 
 
 //------------ Source --------------------------------------------------------
 
-/// A view into a sequence of octets.
-///
-/// Sources form that foundation of decoding. They provide the raw octets to
-/// decoders.
-///
-/// A source can only progress forward over time. It provides the ability to
-/// access the next few bytes as a slice or a [`Bytes`] value, and advance
-/// forward.
-///
-/// _Please note:_ This trait may change as we gain more experience with
-/// decoding in different circumstances. If you implement it for your own
-/// types, we would appreciate feedback what worked well and what didn’t.
 pub trait Source {
-    /// The error produced when the source failed to read more data.
+    type Fragment<'f>: Fragment<'f> where Self: 'f;
     type Error: error::Error;
 
-    /// Returns the current logical postion within the sequence of data.
+
+    //--- Required methods
+
     fn pos(&self) -> Pos;
 
-    /// Request at least `len` bytes to be available.
-    ///
-    /// The method returns the number of bytes that are actually available.
-    /// This may only be smaller than `len` if the source ends with less
-    /// bytes available. It may be larger than `len` but less than the total
-    /// number of bytes still left in the source.
-    ///
-    /// The method can be called multiple times without advancing in between.
-    /// If in this case `len` is larger than when last called, the source
-    /// should try and make the additional data available.
-    ///
-    /// The method should only return an error if the source somehow fails
-    /// to get more data such as an IO error or reset connection.
-    fn request(&mut self, len: usize) -> Result<usize, Self::Error>;
+    fn request<'f>(
+        &'f mut self, len: usize
+    ) -> Result<Self::Fragment<'f>, Self::Error>;
 
-    /// Returns a bytes slice with the available data.
-    ///
-    /// The slice will be at least as long as the value returned by the last
-    /// successful [`request`] call. It may be longer if more data is
-    /// available.
-    ///
-    /// [`request`]: #tymethod.request
-    fn slice(&self) -> &[u8];
 
-    /// Produces a `Bytes` value from part of the data.
-    ///
-    /// The method returns a [`Bytes`] value of the range `start..end` from
-    /// the beginning of the current view of the source. Both indexes must
-    /// not be greater than the value returned by the last successful call
-    /// to [`request`][Self::request].
-    ///
-    /// # Panics
-    ///
-    /// The method panics if `start` or `end` are larger than the result of
-    /// the last successful call to [`request`][Self::request].
-    fn bytes(&self, start: usize, end: usize) -> Bytes;
+    //--- Provided methods
 
-    /// Advance the source by `len` bytes.
-    ///
-    /// The method advances the start of the view provided by the source by
-    /// `len` bytes. This value must not be greater than the value returned
-    /// by the last successful call to [`request`][Self::request].
-    ///
-    /// # Panics
-    ///
-    /// The method panics if `len` is larger than the result of the last
-    /// successful call to [`request`][Self::request].
-    fn advance(&mut self, len: usize);
-
-    /// Skip over the next `len` bytes.
-    ///
-    /// The method attempts to advance the source by `len` bytes or by
-    /// however many bytes are still available if this number is smaller,
-    /// without making these bytes available.
-    ///
-    /// Returns the number of bytes skipped over. This value may only differ
-    /// from len if the remainder of the source contains less than `len`
-    /// bytes.
-    ///
-    /// The default implementation uses `request` and `advance`. However, for
-    /// some sources it may be significantly cheaper to provide a specialised
-    /// implementation.
-    fn skip(&mut self, len: usize) -> Result<usize, Self::Error> {
-        let res = min(self.request(len)?, len);
-        self.advance(res);
-        Ok(res)
+    fn request_exact<'f>(
+        &'f mut self, len: usize
+    ) -> Result<Self::Fragment<'f>, DecodeError<Self::Error>> {
+        let pos = self.pos();
+        let frag = self.request(len)?;
+        if frag.slice().len() < len {
+            Err(DecodeError::content("unexpected end of data", pos))
+        }
+        else {
+            Ok(frag)
+        }
     }
-
-
-    //--- Advanced access
 
     /// Takes a single octet from the source.
     ///
     /// If there aren’t any more octets available from the source, returns
     /// a content error.
     fn take_u8(&mut self) -> Result<u8, DecodeError<Self::Error>> {
-        if self.request(1)? < 1 {
-            return Err(self.content_err("unexpected end of data"))
+        let pos = self.pos();
+        let frag = self.request(1)?;
+        match frag.slice().first().copied() {
+            Some(value) => {
+                frag.consume();
+                Ok(value)
+            }
+            None => {
+                Err(DecodeError::content("unexpected end of data", pos))
+            }
         }
-        let res = self.slice()[0];
-        self.advance(1);
-        Ok(res)
     }
 
     /// Takes an optional octet from the source.
@@ -120,12 +59,37 @@ pub trait Source {
     /// If there aren’t any more octets available from the source, returns
     /// `Ok(None)`.
     fn take_opt_u8(&mut self) -> Result<Option<u8>, Self::Error> {
-        if self.request(1)? < 1 {
-            return Ok(None)
+        let frag = self.request(1)?;
+        match frag.slice().first().copied() {
+            Some(value) => {
+                frag.consume();
+                Ok(Some(value))
+            }
+            None => {
+                Ok(None)
+            }
         }
-        let res = self.slice()[0];
-        self.advance(1);
-        Ok(Some(res))
+    }
+
+    /// Returns the n-th octet if that many octets are available.
+    ///
+    /// Does not consume any fragments.
+    fn peek_opt_nth(
+        &mut self, n: usize
+    ) -> Result<Option<u8>, DecodeError<Self::Error>> {
+        let frag = self.request(n.saturating_add(1))?;
+        let res = frag.slice().get(n).copied();
+        Ok(res)
+    }
+
+    /// Returns the n-th octet if that many octets are available.
+    ///
+    /// Does not consume any fragments.
+    fn peek_nth(&mut self, n: usize) -> Result<u8, DecodeError<Self::Error>> {
+        let pos = self.pos();
+        self.peek_opt_nth(n)?.ok_or_else(|| {
+            DecodeError::content("unexpected end of data", pos)
+        })
     }
 
     /// Returns a content error at the current position of the source.
@@ -136,28 +100,13 @@ pub trait Source {
     }
 }
 
-impl<T: Source> Source for &'_ mut T {
-    type Error = T::Error;
 
-    fn request(&mut self, len: usize) -> Result<usize, Self::Error> {
-        Source::request(*self, len)
-    }
-    
-    fn advance(&mut self, len: usize) {
-        Source::advance(*self, len)
-    }
+//------------ Fragment ------------------------------------------------------
 
-    fn slice(&self) -> &[u8] {
-        Source::slice(*self)
-    }
+pub trait Fragment<'f> {
+    fn slice(&self) -> &[u8];
 
-    fn bytes(&self, start: usize, end: usize) -> Bytes {
-        Source::bytes(*self, start, end)
-    }
-
-    fn pos(&self) -> Pos {
-        Source::pos(*self)
-    }
+    fn consume(self);
 }
 
 
@@ -175,6 +124,263 @@ impl<T: Source> IntoSource for T {
 
     fn into_source(self) -> Self::Source {
         self
+    }
+}
+
+
+//------------ SliceSource ---------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+pub struct SliceSource<'s> {
+    data: &'s [u8],
+    pos: usize,
+}
+
+impl<'s> SliceSource<'s> {
+    pub fn new(data: &'s [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    pub fn remaining(&self) -> &[u8] {
+        self.data
+    }
+}
+
+impl<'s> Source for SliceSource<'s> {
+    type Error = Infallible;
+    type Fragment<'f> = SliceFragment<'s, 'f> where Self: 'f;
+
+    fn pos(&self) -> Pos {
+        self.pos.into()
+    }
+
+    fn request<'f>(
+        &'f mut self, len: usize
+    ) -> Result<Self::Fragment<'f>, Self::Error> {
+        let (head, tail) = match self.data.split_at_checked(len) {
+            Some(some) => some,
+            None => (self.data, b"".as_ref())
+        };
+        Ok(SliceFragment { slice: self, head, tail })
+    }
+}
+
+impl<'a> IntoSource for &'a [u8] {
+    type Source = SliceSource<'a>;
+
+    fn into_source(self) -> Self::Source {
+        SliceSource::new(self)
+    }
+}
+
+
+//------------ SliceFragment -------------------------------------------------
+
+pub struct SliceFragment<'s, 'f> {
+    slice: &'f mut SliceSource<'s>,
+    head: &'f [u8],
+    tail: &'s [u8],
+}
+
+impl<'s, 'f> Fragment<'f> for SliceFragment<'s, 'f> {
+    fn slice(&self) -> &[u8] {
+        self.head
+    }
+
+    fn consume(self) {
+        self.slice.data = self.tail;
+        self.slice.pos += self.head.len();
+    }
+}
+
+
+//------------ ReaderSource --------------------------------------------------
+
+pub struct ReaderSource<R> {
+    reader: R,
+    buf: Vec<u8>,
+    pos: usize,
+}
+
+impl<R: io::Read> Source for ReaderSource<R> {
+    type Fragment<'f> = ReaderFragment<'f> where Self: 'f;
+    type Error = io::Error;
+
+    fn pos(&self) -> Pos {
+        self.pos.into()
+    }
+
+    fn request<'f>(
+        &'f mut self, len: usize
+    ) -> Result<Self::Fragment<'f>, Self::Error> {
+        let cur_len = self.buf.len();
+        if cur_len < len {
+            self.buf.resize(len, 0);
+            self.reader.read_exact(&mut self.buf[cur_len..])?;
+        }
+        Ok(ReaderFragment { buf: &mut self.buf, pos: &mut self.pos, len })
+    }
+}
+
+
+//------------ ReaderFragment ------------------------------------------------
+
+pub struct ReaderFragment<'f> {
+    buf: &'f mut Vec<u8>,
+    pos: &'f mut usize,
+    len: usize,
+}
+
+impl<'f> Fragment<'f> for ReaderFragment<'f> {
+    fn slice(&self) -> &[u8] {
+        &self.buf[..self.len]
+    }
+
+    fn consume(self) {
+        self.buf.copy_within(self.len.., 0);
+        self.buf.truncate(self.buf.len() - self.len);
+        *self.pos += self.len;
+    }
+}
+
+
+//------------ MaybeLimitedSource --------------------------------------------
+
+pub struct MaybeLimitedSource<'a, S> {
+    source: &'a mut S,
+    limit: Option<usize>,
+}
+
+impl<'a, S> MaybeLimitedSource<'a, S> {
+    pub fn new(source: &'a mut S, limit: Option<usize>) -> Self {
+        Self { source, limit }
+    }
+
+    pub fn source_mut(&mut self) -> &mut S {
+        self.source
+    }
+
+    pub fn limit(&self) -> Option<usize> {
+        self.limit
+    }
+}
+
+impl<'a, S: Source> Source for MaybeLimitedSource<'a, S> {
+    type Fragment<'f> = MaybeLimitedFragment<'f, S> where Self: 'f, S: 'f;
+    type Error = S::Error;
+
+    fn pos(&self) -> Pos {
+        self.source.pos()
+    }
+
+    fn request<'f>(
+        &'f mut self, mut len: usize
+    ) -> Result<MaybeLimitedFragment<'f, S>, Self::Error> {
+        if let Some(limit) = self.limit {
+            len = std::cmp::min(len, limit);
+        }
+        Ok(MaybeLimitedFragment {
+            fragment: self.source.request(len)?,
+            limit: &mut self.limit,
+            len
+        })
+    }
+}
+
+
+//------------ MaybeLimitedFragment ------------------------------------------
+
+pub struct MaybeLimitedFragment<'f, S: Source + 'f> {
+    fragment: S::Fragment<'f>,
+    limit: &'f mut Option<usize>,
+    len: usize,
+}
+
+impl<'f, S: Source + 'f> Fragment<'f> for MaybeLimitedFragment<'f, S> {
+    fn slice(&self) -> &[u8] {
+        self.fragment.slice()
+    }
+
+    fn consume(self) {
+        self.fragment.consume();
+        if let Some(limit) = self.limit {
+            *limit -= self.len
+        }
+    }
+}
+
+
+//------------ LimitedSource -------------------------------------------------
+
+pub struct LimitedSource<'a, S> {
+    source: &'a mut S,
+    limit: usize,
+}
+
+impl<'a, S> LimitedSource<'a, S> {
+    pub fn new(source: &'a mut S, limit: usize) -> Self {
+        Self { source, limit }
+    }
+
+    pub fn source_mut(&mut self) -> &mut S {
+        self.source
+    }
+
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+}
+
+impl<'a, S: Source> LimitedSource<'a, S> {
+    pub fn request_all<'f>(
+        &'f mut self
+    ) -> Result<LimitedFragment<'f, S>, DecodeError<S::Error>>
+    where S: 'f {
+        self.request_exact(self.limit)
+    }
+
+    pub fn is_exhausted(&self) -> bool {
+        self.limit == 0
+    }
+}
+
+impl<'a, S: Source> Source for LimitedSource<'a, S> {
+    type Fragment<'f> = LimitedFragment<'f, S> where Self: 'f, S: 'f;
+    type Error = S::Error;
+
+    fn pos(&self) -> Pos {
+        self.source.pos()
+    }
+
+    fn request<'f>(
+        &'f mut self, len: usize
+    ) -> Result<LimitedFragment<'f, S>, Self::Error> {
+        let len = std::cmp::min(len, self.limit);
+        Ok(LimitedFragment {
+            fragment: self.source.request(len)?,
+            limit: &mut self.limit,
+            len
+        })
+    }
+}
+
+
+//------------ LimitedFragment -----------------------------------------------
+
+pub struct LimitedFragment<'f, S: Source + 'f> {
+    fragment: S::Fragment<'f>,
+    limit: &'f mut usize,
+    len: usize,
+}
+
+impl<'f, S: Source + 'f> Fragment<'f> for LimitedFragment<'f, S> {
+    fn slice(&self) -> &[u8] {
+        self.fragment.slice()
+    }
+
+    fn consume(self) {
+        self.fragment.consume();
+        *self.limit -= self.len
     }
 }
 
@@ -206,578 +412,6 @@ impl ops::Add for Pos {
 impl fmt::Display for Pos {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-
-//------------ BytesSource ---------------------------------------------------
-
-/// A source for a bytes value.
-#[derive(Clone, Debug)]
-pub struct BytesSource {
-    /// The bytes.
-    data: Bytes,
-
-    /// The current read position in the data.
-    pos: usize,
-
-    /// The offset for the reported position.
-    ///
-    /// This is the value reported by `Source::pos` when `self.pos` is zero.
-    offset: Pos,
-}
-
-impl BytesSource {
-    /// Creates a new bytes source from a bytes values.
-    pub fn new(data: Bytes) -> Self {
-        BytesSource { data, pos: 0, offset: 0.into() }
-    }
-
-    /// Creates a new bytes source with an explicit offset.
-    ///
-    /// When this function is used to create a bytes source, `Source::pos`
-    /// will report a value increates by `offset`.
-    pub fn with_offset(data: Bytes, offset: Pos) -> Self {
-        BytesSource { data, pos: 0, offset }
-    }
-
-    /// Returns the remaining length of data.
-    pub fn len(&self) -> usize {
-        self.data.len()
-    }
-
-    /// Returns whether there is any data remaining.
-    pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
-    }
-
-    /// Splits the first `len` bytes off the source and returns them.
-    ///
-    /// # Panics
-    ///
-    /// This method panics of `len` is larger than `self.len()`.
-    pub fn split_to(&mut self, len: usize) -> Bytes {
-        let res = self.data.split_to(len);
-        self.pos += len;
-        res
-    }
-
-    /// Converts the source into the remaining bytes.
-    pub fn into_bytes(self) -> Bytes {
-        self.data
-    }
-}
-
-impl Source for BytesSource {
-    type Error = Infallible;
-
-    fn pos(&self) -> Pos {
-        self.offset + self.pos.into()
-    }
-
-    fn request(&mut self, _len: usize) -> Result<usize, Self::Error> {
-        Ok(self.data.len())
-    }
-
-    fn slice(&self) -> &[u8] {
-        self.data.as_ref()
-    }
-
-    fn bytes(&self, start: usize, end: usize) -> Bytes {
-        self.data.slice(start..end)
-    }
-
-    fn advance(&mut self, len: usize) {
-        assert!(len <= self.data.len());
-        bytes::Buf::advance(&mut self.data, len);
-        self.pos += len;
-    }
-}
-
-impl IntoSource for Bytes {
-    type Source = BytesSource;
-
-    fn into_source(self) -> Self::Source {
-        BytesSource::new(self)
-    }
-}
-
-
-//------------ SliceSource ---------------------------------------------------
-
-#[derive(Clone, Copy, Debug)]
-pub struct SliceSource<'a> {
-    data: &'a [u8],
-    pos: usize
-}
-
-impl<'a> SliceSource<'a> {
-    /// Creates a new bytes source from a slice.
-    pub fn new(data: &'a [u8]) -> Self {
-        SliceSource { data, pos: 0 }
-    }
-
-    /// Returns the remaining length of data.
-    pub fn len(&self) -> usize {
-        self.data.len()
-    }
-
-    /// Returns whether there is any data remaining.
-    pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
-    }
-
-    /// Splits the first `len` bytes off the source and returns them.
-    ///
-    /// # Panics
-    ///
-    /// This method panics of `len` is larger than `self.len()`.
-    pub fn split_to(&mut self, len: usize) -> &'a [u8] {
-        let (left, right) = self.data.split_at(len);
-        self.data = right;
-        self.pos += len;
-        left
-    }
-}
-
-impl Source for SliceSource<'_> {
-    type Error = Infallible;
-
-    fn pos(&self) -> Pos {
-        self.pos.into()
-    }
-
-    fn request(&mut self, _len: usize) -> Result<usize, Self::Error> {
-        Ok(self.data.len())
-    }
-
-    fn advance(&mut self, len: usize) {
-        assert!(len <= self.data.len());
-        self.data = &self.data[len..];
-        self.pos += len;
-    }
-
-    fn slice(&self) -> &[u8] {
-        self.data
-    }
-
-    fn bytes(&self, start: usize, end: usize) -> Bytes {
-        Bytes::copy_from_slice(&self.data[start..end])
-    }
-}
-
-impl<'a> IntoSource for &'a [u8] {
-    type Source = SliceSource<'a>;
-
-    fn into_source(self) -> Self::Source {
-        SliceSource::new(self)
-    }
-}
-
-
-//------------ LimitedSource -------------------------------------------------
-
-/// A source that can be limited to a certain number of octets.
-///
-/// This type wraps another source and allows access to be limited to a
-/// certain number of octets. It will never provide access to more than
-/// that number of octets. Any attempt to advance over more octets will
-/// fail with a malformed error.
-///
-/// The limit is, however, independent of the underlying source. It can
-/// be larger than the number of octets actually available in the source.
-///
-/// The limit can be changed or even removed at any time.
-#[derive(Clone, Debug)]
-pub struct LimitedSource<S> {
-    /// The source this value wraps.
-    source: S,
-
-    /// The current limit.
-    ///
-    /// If `limit` is `None`, there is no limit. If there is a limit, it
-    /// will be decreased by calls to `advance` accordingly. I.e., this is
-    /// the current limit, not the original limit.
-    limit: Option<usize>,
-}
-
-/// # General Management
-///
-impl<S> LimitedSource<S> {
-    /// Creates a new limited source for the given source.
-    ///
-    /// The return limited source will have no limit just yet.
-    pub fn new(source: S) -> Self {
-        LimitedSource {
-            source,
-            limit: None
-        }
-    }
-
-    /// Unwraps the value and returns the source it was created from.
-    pub fn unwrap(self) -> S {
-        self.source
-    }
-
-    /// Returns the current limit.
-    ///
-    /// Returns `None` if there is no limit. Otherwise, the number returned
-    /// is the number of remaining octets before the limit is reached. This
-    /// does not necessarily mean that that many octets are actually
-    /// available in the underlying source.
-    pub fn limit(&self) -> Option<usize> {
-        self.limit
-    }
-
-    /// Sets a more strict limit.
-    ///
-    /// The method will panic (!) if you are trying to set a new limit that
-    /// is larger than the current limit or if you are trying to remove
-    /// the limit by passing `None` if there currently is a limit set.
-    ///
-    /// Returns the old limit.
-    pub fn limit_further(&mut self, limit: Option<usize>) -> Option<usize> {
-        if let Some(cur) = self.limit {
-            match limit {
-                Some(limit) => assert!(limit <= cur),
-                None => panic!("relimiting to unlimited"),
-            }
-        }
-        mem::replace(&mut self.limit, limit)
-    }
-
-    /// Unconditionally sets a new limit.
-    ///
-    /// If you pass `None`, the limit will be removed.
-    pub fn set_limit(&mut self, limit: Option<usize>) {
-        self.limit = limit
-    }
-}
-
-/// # Advanced Access
-///
-impl<S: Source> LimitedSource<S> {
-    /// Skip over all remaining octets until the current limit is reached.
-    ///
-    /// If there currently is no limit, the method will panic. Otherwise it
-    /// will simply advance to the end of the limit which may be something
-    /// the underlying source doesn’t like and thus produce an error.
-    pub fn skip_all(&mut self) -> Result<(), DecodeError<S::Error>> {
-        let limit = self.limit.unwrap();
-        if self.request(limit)? < limit {
-            return Err(self.content_err("unexpected end of data"))
-        }
-        self.advance(limit);
-        Ok(())
-    }
-
-    /// Returns a bytes value containing all octets until the current limit.
-    ///
-    /// If there currently is no limit, the method will panic. Otherwise it
-    /// tries to acquire a bytes value for the octets from the current
-    /// position to the end of the limit and advance to the end of the limit.
-    ///
-    /// This will result in a source error if the underlying source returns
-    /// an error. It will result in a content error if the underlying source
-    /// ends before the limit is reached.
-    pub fn take_all(&mut self) -> Result<Bytes, DecodeError<S::Error>> {
-        let limit = self.limit.unwrap();
-        if self.request(limit)? < limit {
-            return Err(self.content_err("unexpected end of data"))
-        }
-        let res = self.bytes(0, limit);
-        self.advance(limit);
-        Ok(res)
-    }
-
-    /// Checks whether the end of the limit has been reached.
-    ///
-    /// If a limit is currently set, the method will return a malformed
-    /// error if it is larger than zero, i.e., if there are octets left to
-    /// advance over before reaching the limit.
-    ///
-    /// If there is no limit set, the method will try to access one single
-    /// octet and return a malformed error if that is actually possible, i.e.,
-    /// if there are octets left in the underlying source.
-    ///
-    /// Any source errors are passed through. If there the data is not
-    /// exhausted as described above, a content error is created.
-    pub fn exhausted(&mut self) -> Result<(), DecodeError<S::Error>> {
-        match self.limit {
-            Some(0) => Ok(()),
-            Some(_limit) => Err(self.content_err("trailing data")),
-            None => {
-                if self.source.request(1)? == 0 {
-                    Ok(())
-                }
-                else {
-                    Err(self.content_err("trailing data"))
-                }
-            }
-        }
-    }
-}
-
-impl<S: Source> Source for LimitedSource<S> {
-    type Error = S::Error;
-
-    fn pos(&self) -> Pos {
-        self.source.pos()
-    }
-
-    fn request(&mut self, len: usize) -> Result<usize, Self::Error> {
-        if let Some(limit) = self.limit {
-            Ok(min(limit, self.source.request(min(limit, len))?))
-        }
-        else {
-            self.source.request(len)
-        }
-    }
-
-    fn advance(&mut self, len: usize) {
-        if let Some(limit) = self.limit {
-            assert!(
-                len <= limit,
-                "advanced past end of limit"
-            );
-            self.limit = Some(limit - len);
-        }
-        self.source.advance(len)
-    }
-
-    fn slice(&self) -> &[u8] {
-        let res = self.source.slice();
-        if let Some(limit) = self.limit {
-            if res.len() > limit {
-                return &res[..limit]
-            }
-        }
-        res
-    }
-
-    fn bytes(&self, start: usize, end: usize) -> Bytes {
-        if let Some(limit) = self.limit {
-            assert!(start <= limit);
-            assert!(end <= limit);
-        }
-        self.source.bytes(start, end)
-    }
-}
-
-
-//------------ CaptureSource -------------------------------------------------
-
-/// A source that captures what has been advanced over.
-///
-/// A capture source wraps a mutable reference to some other source and
-/// provides the usual source access. However, instead of dropping octets
-/// that have been advanced over, it keeps them around and allows taking
-/// them out as a bytes value.
-///
-/// This type is used by [`Constructed::capture`].
-///
-/// [`Constructed::capture`]: struct.Constructed.html#method.capture
-pub struct CaptureSource<'a, S: 'a> {
-    /// The wrapped real source.
-    source: &'a mut S,
-
-    /// The number of bytes the source has promised to have for us.
-    len: usize,
-
-    /// The position in the source our view starts at.
-    pos: usize,
-}
-
-impl<'a, S: Source> CaptureSource<'a, S> {
-    /// Creates a new capture source using a reference to some other source.
-    pub fn new(source: &'a mut S) -> Self {
-        CaptureSource {
-            source,
-            len: 0,
-            pos: 0,
-        }
-    }
-
-    /// Converts the capture source into the captured bytes.
-    pub fn into_bytes(self) -> Bytes {
-        let res = self.source.bytes(0, self.pos);
-        self.skip();
-        res
-    }
-
-    /// Drops the captured bytes.
-    ///
-    /// Advances the underlying source to the end of the captured bytes.
-    pub fn skip(self) {
-        self.source.advance(self.pos)
-    }
-}
-
-impl<'a, S: Source + 'a> Source for CaptureSource<'a, S> {
-    type Error = S::Error;
-
-    fn pos(&self) -> Pos {
-        self.source.pos() + self.pos.into()
-    }
-
-    fn request(&mut self, len: usize) -> Result<usize, Self::Error> {
-        self.len = self.source.request(self.pos + len)?;
-        Ok(self.len - self.pos)
-    }
-
-    fn slice(&self) -> &[u8] {
-        &self.source.slice()[self.pos..]
-    }
-
-    fn bytes(&self, start: usize, end: usize) -> Bytes {
-        let start = start + self.pos;
-        let end = end + self.pos;
-        assert!(
-            self.len >= start,
-            "start past the end of data"
-        );
-        assert!(
-            self.len >= end,
-            "end past the end of data"
-        );
-        self.source.bytes(start, end)
-    }
-
-    fn advance(&mut self, len: usize) {
-        assert!(
-            self.len >= self.pos + len,
-            "advanced past the end of data"
-        );
-        self.pos += len;
-    }
-}
-
-
-//============ Tests =========================================================
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn take_u8() {
-        let mut source = b"123".into_source();
-        assert_eq!(source.take_u8().unwrap(), b'1');
-        assert_eq!(source.take_u8().unwrap(), b'2');
-        assert_eq!(source.take_u8().unwrap(), b'3');
-        assert!(source.take_u8().is_err())
-    }
-
-    #[test]
-    fn take_opt_u8() {
-        let mut source = b"123".into_source();
-        assert_eq!(source.take_opt_u8().unwrap(), Some(b'1'));
-        assert_eq!(source.take_opt_u8().unwrap(), Some(b'2'));
-        assert_eq!(source.take_opt_u8().unwrap(), Some(b'3'));
-        assert_eq!(source.take_opt_u8().unwrap(), None);
-    }
-
-    #[test]
-    fn bytes_impl() {
-        let mut bytes = Bytes::from_static(b"1234567890").into_source();
-        assert!(bytes.request(4).unwrap() >= 4);
-        assert!(&Source::slice(&bytes)[..4] == b"1234");
-        assert_eq!(bytes.bytes(2, 4), Bytes::from_static(b"34"));
-        Source::advance(&mut bytes, 4);
-        assert!(bytes.request(4).unwrap() >= 4);
-        assert!(&Source::slice(&bytes)[..4] == b"5678");
-        Source::advance(&mut bytes, 4);
-        assert_eq!(bytes.request(4).unwrap(), 2);
-        assert!(&Source::slice(&bytes) == b"90");
-        bytes.advance(2);
-        assert_eq!(bytes.request(4).unwrap(), 0);
-    }
-
-    #[test]
-    fn slice_impl() {
-        let mut bytes = b"1234567890".into_source();
-        assert!(bytes.request(4).unwrap() >= 4);
-        assert!(&bytes.slice()[..4] == b"1234");
-        assert_eq!(bytes.bytes(2, 4), Bytes::from_static(b"34"));
-        bytes.advance(4);
-        assert!(bytes.request(4).unwrap() >= 4);
-        assert!(&bytes.slice()[..4] == b"5678");
-        bytes.advance(4);
-        assert_eq!(bytes.request(4).unwrap(), 2);
-        assert!(&bytes.slice() == b"90");
-        bytes.advance(2);
-        assert_eq!(bytes.request(4).unwrap(), 0);
-    }
-
-    #[test]
-    fn limited_source() {
-        let mut the_source = LimitedSource::new(
-            b"12345678".into_source()
-        );
-        the_source.set_limit(Some(4));
-
-        let mut source = the_source.clone();
-        assert!(source.exhausted().is_err());
-        assert_eq!(source.request(6).unwrap(), 4);
-        source.advance(2);
-        assert!(source.exhausted().is_err());
-        assert_eq!(source.request(6).unwrap(), 2);
-        source.advance(2);
-        source.exhausted().unwrap();
-        assert_eq!(source.request(6).unwrap(), 0);
-
-        let mut source = the_source.clone();
-        source.skip_all().unwrap();
-        let source = source.unwrap();
-        assert_eq!(source.slice(), b"5678");
-
-        let mut source = the_source.clone();
-        assert_eq!(source.take_all().unwrap(), Bytes::from_static(b"1234"));
-        source.exhausted().unwrap();
-        let source = source.unwrap();
-        assert_eq!(source.slice(), b"5678");
-    }
-
-    #[test]
-    #[should_panic]
-    fn limited_source_far_advance() {
-        let mut source = LimitedSource::new(
-            b"12345678".into_source()
-        );
-        source.set_limit(Some(4));
-        assert_eq!(source.request(6).unwrap(), 4);
-        source.advance(4);
-        assert_eq!(source.request(6).unwrap(), 0);
-        source.advance(6); // panics
-    }
-
-    #[test]
-    #[should_panic]
-    fn limit_further() {
-        let mut source = LimitedSource::new(b"12345".into_source());
-        source.set_limit(Some(4));
-        source.limit_further(Some(5)); // panics
-    }
-
-    #[test]
-    fn capture_source() {
-        let mut source = b"1234567890".into_source();
-        {
-            let mut capture = CaptureSource::new(&mut source);
-            assert_eq!(capture.request(4).unwrap(), 10);
-            capture.advance(4);
-            assert_eq!(capture.into_bytes(), Bytes::from_static(b"1234"));
-        }
-        assert_eq!(source.data, b"567890");
-
-        let mut source = b"1234567890".into_source();
-        {
-            let mut capture = CaptureSource::new(&mut source);
-            assert_eq!(capture.request(4).unwrap(), 10);
-            capture.advance(4);
-            capture.skip();
-        }
-        assert_eq!(source.data, b"567890");
     }
 }
 

--- a/src/length.rs
+++ b/src/length.rs
@@ -1,10 +1,15 @@
-//! The Length Octets.
+//! The length octets.
 //!
-//! This is a private module. Its public items are re-exported by the parent.
+//! This is a private module. The [`Length`] definied herein is not
+//! publicly exposed.
+
+#![allow(dead_code)] // XXX REMOVE!!!
 
 use std::io;
-use crate::decode::{DecodeError, Source};
+use std::marker::PhantomData;
 use crate::mode::Mode;
+use crate::decode::{DecodeError, Fragment, Source};
+
 
 
 //------------ Length -------------------------------------------------------
@@ -31,218 +36,391 @@ use crate::mode::Mode;
 /// length of the content octets.
 ///
 /// Under both CER and DER rules, a definite length must be encoded in the
-/// minimum number of octets.
-///
-/// # Limitation
-///
-/// The current implementation is limited to 4 length bytes on 32 bit systems
-/// and 5 length bytes on 64 bit sytems.
+/// minimum number of octets. Because of this, the type is generic over
+/// the mode.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Length {
-    /// A length value in definite form.
+pub struct Length<M> {
+    /// The length.
     ///
-    /// Provides the actual length of the content in octets.
-    Definite(usize),
+    /// If this is `None`, the length is indefinite. Otherwise it is definite
+    /// with the given value.
+    length: Option<Definite>,
 
-    /// A length value in indefinite form.
-    ///
-    /// In this form, the end of a value is determined by a special tag.
-    Indefinite
+    /// A marker for the mode.
+    marker: PhantomData<M>,
 }
 
-impl Length {
-    /// Takes a length value from the beginning of a source.
-    pub fn take_from<S: Source>(
-        source: &mut S,
-        mode: Mode
-    ) -> Result<Self, DecodeError<S::Error>> {
-        match source.take_u8()? {
-            // Bit 7 clear: other bits are the length
-            n if (n & 0x80) == 0 => Ok(Length::Definite(n as usize)),
+impl<M> Length<M> {
+    /// Creates a new length from the given optional length.
+    ///
+    /// If the length is `None`, creates an indefinite length value.
+    fn new(length: Option<usize>) -> Self {
+        Self { length: length.map(Definite), marker: PhantomData }
+    }
 
-            // Bit 7 set: other bits are the number of octets that 
-            // encode the length. Unless they are all 0, in which case this
-            // is the indefinite form.
-            0x80 => Ok(Length::Indefinite),
-            0x81 => {
-                let len = source.take_u8()? as usize;
-                if mode.is_ber() || len > 127 {
-                    Ok(Length::Definite(len))
-                }
-                else {
-                    Err(source.content_err("invalid length"))
-                }
-            }
-            0x82 => {
-                let len =
-                    ((source.take_u8()? as usize) << 8) |
-                    (source.take_u8()? as usize);
-                if mode.is_ber() || len > 255 {
-                    Ok(Length::Definite(len))
-                }
-                else {
-                    Err(source.content_err("invalid length"))
-                }
-            }
-            0x83 => {
-                let len =
-                    ((source.take_u8()? as usize) << 16) |
-                    ((source.take_u8()? as usize) << 8) |
-                    (source.take_u8()? as usize);
-                if mode.is_ber() || len > 0xFFFF {
-                    Ok(Length::Definite(len))
-                }
-                else {
-                    Err(source.content_err("invalid length"))
-                }
-            }
-            0x84 => {
-                let len =
-                    ((source.take_u8()? as usize) << 24) |
-                    ((source.take_u8()? as usize) << 16) |
-                    ((source.take_u8()? as usize) << 8) |
-                    (source.take_u8()? as usize);
-                if mode.is_ber() || len > 0x00FF_FFFF {
-                    Ok(Length::Definite(len))
-                }
-                else {
-                    Err(source.content_err("invalid length"))
-                }
-            }
-            _ => {
-                // We only implement up to two length bytes for now.
-                Err(source.content_err(
-                    "lengths over 4 bytes not implemented"
-                ))
-            }
-        }
+    /// Returns the length if it is definite.
+    pub fn definite(self) -> Option<usize> {
+        self.length.map(|x| x.0)
     }
 
     /// Returns whether the length is definite and zero.
-    pub fn is_zero(&self) -> bool {
-        matches!(*self, Length::Definite(0))
+    pub fn is_zero(self) -> bool {
+        self.definite() == Some(0)
+    }
+
+    /// Parses a length from a source in BER mode.
+    pub fn take_from<S: Source>(
+        source: &mut S
+    ) -> Result<Self, DecodeError<S::Error>>
+    where M: Mode {
+        // This branch should be optimized away after monomorphisation.
+        if M::IS_RESTRICTED {
+            Self::take_from_restricted(source)
+        }
+        else {
+            Self::take_from_relaxed(source)
+        }
+    }
+
+    /// Parses a length from a source in BER mode.
+    fn take_from_relaxed<S: Source>(
+        source: &mut S
+    ) -> Result<Self, DecodeError<S::Error>> {
+        // Determine the length of the whole thing (which is one more than
+        // what’s returned for multi).
+        // Return early for trivial cases, don’t forget to consume the first
+        // octet in this case.
+        let len = match FirstOctet::peek(source)? {
+            FirstOctet::Single(res) => {
+                source.take_u8()?;
+                return Ok(res)
+            }
+            FirstOctet::Multi(len) => len + 1,
+        };
+
+        // Find the first non-zero octet. This will be the index of the start
+        // of our source slice.
+        let start = (1..len).into_iter().find_map(|i| {
+            match source.peek_nth(i) {
+                Ok(value) if value != 0 => Some(Ok(i)),
+                Ok(_) => None,
+                Err(err) => Some(Err(err))
+            }
+        }).transpose()?;
+
+        // If we have only zeros, the result is zero. We need to consume all
+        // the zeros, though.
+        let Some(start) = start else {
+            source.request_exact(len)?.consume();
+            return Ok(Self::new(Some(0)))
+        };
+
+        // Get the source slice.
+        let pos = source.pos();
+        let frag = source.request_exact(len)?;
+        let Some(from) = frag.slice().get(start..) else {
+            // This shouldn’t happen ...
+            return Err(DecodeError::content("unexpected end of data", pos))
+        };
+
+        // Get the target slice.
+        let mut res = 0usize.to_ne_bytes();
+        let start = res.len().saturating_add(
+            start
+        ).saturating_sub(len);
+        let Some(to) = res.as_mut_slice().get_mut(start..) else {
+            // This means the length is too big for a usize.
+            return Err(DecodeError::content("excessive length", pos))
+        };
+
+        // Now copy.
+        debug_assert_eq!(from.len(), to.len());
+        to.copy_from_slice(from);
+
+        frag.consume();
+
+        return Ok(Self::new(Some(usize::from_be_bytes(res))))
+    }
+
+    /// Parses a length from a source in CER/DER mode.
+    fn take_from_restricted<S: Source>(
+        source: &mut S
+    ) -> Result<Self, DecodeError<S::Error>> {
+        // The difference to the BER case is the second octet can’t be zero
+        // and it can’t be less that 0x80 if it is the last octet as well.
+        // In both cases, there is a shorter encoding.
+
+        // Determine the length of the whole thing (which is one more than
+        // what’s returned for multi).
+        // Return early for trivial cases, don’t forget to consume the first
+        // octet in this case.
+        let len = match FirstOctet::peek(source)? {
+            FirstOctet::Single(res) => {
+                source.take_u8()?;
+                return Ok(res)
+            }
+            FirstOctet::Multi(len) => len + 1,
+        };
+
+        // Now look at the second octet (i.e., index 1) to check for the
+        // errors mentioned above.
+        let second = source.peek_nth(1)?;
+        if second == 0 || (second < 0x80 && len == 2) {
+            return Err(source.content_err("illegal length in CER/DER"))
+        }
+
+        // Get the source slice.
+        let pos = source.pos();
+        let frag = source.request_exact(len)?;
+        let Some(from) = frag.slice().get(1..) else {
+            // This shouldn’t happen ...
+            return Err(DecodeError::content("unexpected end of data", pos))
+        };
+
+        // Get the target slice.
+        let mut res = 0usize.to_ne_bytes();
+        let start = res.len().saturating_sub(len).saturating_add(1);
+        let Some(to) = res.as_mut_slice().get_mut(start..) else {
+            // This means the length is too big for a usize.
+            return Err(DecodeError::content("excessive length", pos))
+        };
+
+        // Now copy.
+        debug_assert_eq!(from.len(), to.len());
+        to.copy_from_slice(from);
+
+        frag.consume();
+
+        return Ok(Self::new(Some(usize::from_be_bytes(res))))
     }
 
     /// Returns the length of the encoded representation of the value.
-    #[cfg(not(target_pointer_width = "64"))]
-    pub fn encoded_len(&self) -> usize {
-        match *self {
-            Length::Indefinite => 1,
-            Length::Definite(len) => {
-                if len < 0x80 { 1 }
-                else if len < 0x1_00 { 2 }
-                else if len < 0x1_0000 { 3 }
-                else if len < 0x100_0000 { 4 }
-                else {
-                    panic!("excessive length")
-                }
-            }
+    pub fn encoded_len(self) -> usize {
+        match self.length {
+            Some(definite) => definite.encoded_len(),
+            None => 1,
         }
     }
 
-    /// Returns the length of the encoded representation of the value.
-    #[cfg(target_pointer_width = "64")]
-    pub fn encoded_len(&self) -> usize {
-        match *self {
-            Length::Indefinite => 1,
-            Length::Definite(len) => {
-                if len < 0x80 { 1 }
-                else if len < 0x1_00 { 2 }
-                else if len < 0x1_0000 { 3 }
-                else if len < 0x100_0000 { 4 }
-                else if len < 0x1_0000_0000 { 5 }
-                else {
-                    panic!("excessive length")
-                }
-            }
+    /// Appends the encoded length to the end of `target`.
+    pub fn append_encoded(self, target: &mut Vec<u8>) {
+        match self.length {
+            Some(definite) => definite.append_encoded(target),
+            None => target.push(0x80),
         }
     }
 
-    /// Writes the encoded value to a target.
-    #[cfg(target_pointer_width = "64")]
+    /// Writes the encoded length to the given writer.
     pub fn write_encoded<W: io::Write>(
-        &self,
-        target: &mut W
+        self, target: &mut W
     ) -> Result<(), io::Error> {
-        match *self {
-            Length::Indefinite => {
-                let buf = [0x80];
-                target.write_all(&buf)
-            }
-            Length::Definite(len) => {
-                if len < 0x80 {
-                    let buf = [len as u8];
-                    target.write_all(&buf)
-                }
-                else if len < 0x1_00 {
-                    let buf = [0x81, len as u8];
-                    target.write_all(&buf)
-                }
-                else if len < 0x1_0000 {
-                    let buf = [
-                        0x82, (len >> 8) as u8, len as u8
-                    ];
-                    target.write_all(&buf)
-
-                }
-                else if len < 0x100_0000 {
-                    let buf = [
-                        0x83, (len >> 16) as u8, (len >> 8) as u8, len as u8
-                    ];
-                    target.write_all(&buf)
-                }
-                else if len < 0x1_0000_0000 {
-                    let buf = [
-                        0x84,
-                        (len >> 24) as u8, (len >> 16) as u8,
-                        (len >> 8) as u8, len as u8
-                    ];
-                    target.write_all(&buf)
-                }
-                else {
-                    panic!("excessive length")
-                }
-            }
-        }
-    }
-
-    /// Writes the encoded value to a target.
-    #[cfg(not(target_pointer_width = "64"))]
-    pub fn write_encoded<W: io::Write>(
-        &self,
-        target: &mut W
-    ) -> Result<(), io::Error> {
-        match *self {
-            Length::Indefinite => {
-                let buf = [0x80];
-                target.write_all(&buf)
-            }
-            Length::Definite(len) => {
-                if len < 0x80 {
-                    let buf = [len as u8];
-                    target.write_all(&buf)
-                }
-                else if len < 0x1_00 {
-                    let buf = [0x81, len as u8];
-                    target.write_all(&buf)
-                }
-                else if len < 0x1_0000 {
-                    let buf = [
-                        0x82, (len >> 8) as u8, len as u8
-                    ];
-                    target.write_all(&buf)
-
-                }
-                else if len < 0x100_0000 {
-                    let buf = [
-                        0x83, (len >> 16) as u8, (len >> 8) as u8, len as u8
-                    ];
-                    target.write_all(&buf)
-                }
-                else {
-                    panic!("excessive length")
-                }
-            }
+        match self.length {
+            Some(definite) => definite.write_encoded(target),
+            None => target.write_all(&[0x80]),
         }
     }
 }
+
+
+//------------ FirstOctet ---------------------------------------------------
+
+/// The first octet of the encoded length.
+enum FirstOctet<M> {
+    /// The first octet is a length in and of itself.
+    Single(Length<M>),
+
+    /// The first octet indicates the number of octets to follow.
+    Multi(usize),
+}
+
+impl<M> FirstOctet<M> {
+    /// Look at the first octet and check what it means.
+    fn peek<S: Source>(
+        source: &mut S
+    ) -> Result<Self, DecodeError<S::Error>> {
+        match source.peek_nth(0)? {
+            // Bit 7 clear: single.
+            n if (n & 0x80) == 0 => {
+                Ok(Self::Single(Length::new(Some(n as usize))))
+            }
+
+            // 0x80: indefinite.
+            0x80 => Ok(Self::Single(Length::new(None))),
+
+            // 0xFF: illegal.
+            0xFF => return Err(source.content_err("illegal length octets")),
+
+            // anything else: clear left bit, number of octets.
+            n => Ok(Self::Multi((n & 0x7F) as usize))
+        }
+    }
+}
+
+
+//------------ Definite ------------------------------------------------------
+
+/// A definite length.
+///
+/// This is a newtype of `usize` which allows us to do all the encoding
+/// things on it.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+struct Definite(usize);
+
+impl Definite {
+    const LEN: usize = 0usize.to_ne_bytes().len();
+
+    fn encoded_len(self) -> usize {
+        if self.0 > 0x7F {
+            let idx = self.encoded_start_idx();
+            debug_assert!(idx < Self::LEN);
+
+            Self::LEN - idx + 1
+        }
+        else {
+            1
+        }
+    }
+
+    fn append_encoded(self, target: &mut Vec<u8>) {
+        if self.0 > 0x7F {
+            let idx = self.encoded_start_idx();
+            debug_assert!(idx < Self::LEN);
+
+            // LEN will never be greater than 126 bytes. Also, `idx` won’t be
+            // greater than LEN, so the subtraction here is fine.
+            target.push(((Self::LEN - idx) | 0x80) as u8);
+
+            // Panic: idx can’t be bigger than LEN, so this can’t panic.
+            #[allow(clippy::slicing_indexing)]
+            target.extend_from_slice(
+                &self.0.to_be_bytes()[idx..]
+            )
+        }
+        else {
+            target.push(self.0 as u8)
+        }
+    }
+
+    fn write_encoded<W: io::Write>(
+        self, target: &mut W
+    ) -> Result<(), io::Error> {
+        if self.0 > 0x7F {
+            let idx = self.encoded_start_idx();
+            debug_assert!(idx < Self::LEN);
+
+            // LEN will never be greater than 126 bytes. Also, `idx` won’t be
+            // greater than LEN, so the subtraction here is fine.
+            target.write_all(&[((Self::LEN - idx) | 0x80) as u8])?;
+
+            // Panic: idx can’t be bigger than LEN, so this can’t panic.
+            #[allow(clippy::slicing_indexing)]
+            target.write_all(
+                &self.0.to_be_bytes()[idx..]
+            )
+        }
+        else {
+            target.write_all(&[self.0 as u8])
+        }
+    }
+
+    /// Returns the index of the first non-zero octet of `len`.
+    fn encoded_start_idx(self) -> usize {
+        (self.0.leading_zeros().next_multiple_of(8) / 8) as usize
+    }
+}
+
+
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod test {
+    use crate::decode::{ContentError, SliceSource};
+    use crate::mode::{Ber, Der};
+    use super::*;
+
+    #[test]
+    fn ber_take_from() {
+        fn take_from<const N: usize>(
+            src: &[u8; N]
+        ) -> Result<Option<usize>, ContentError> {
+            let mut src = SliceSource::new(src.as_ref());
+            let res = Length::<Ber>::take_from(&mut src)?;
+            if src.remaining().is_empty() {
+                Ok(res.definite())
+            }
+            else {
+                Err(ContentError::from_static("TRAILING DATA"))
+            }
+        }
+
+        assert_eq!(take_from(b"\x00").unwrap(), Some(0x00));
+        assert_eq!(take_from(b"\x12").unwrap(), Some(0x12));
+        assert_eq!(take_from(b"\x7f").unwrap(), Some(0x7f));
+        assert_eq!(take_from(b"\x80").unwrap(), None);
+        assert_eq!(take_from(b"\x81\x00").unwrap(), Some(0));
+        assert_eq!(take_from(b"\x81\xF0").unwrap(), Some(0xF0));
+        assert_eq!(take_from(b"\x82\x00\x00").unwrap(), Some(0));
+        assert_eq!(take_from(b"\x82\xF0\x0E").unwrap(), Some(0xF00E));
+        assert_eq!(take_from(b"\x82\x00\x0E").unwrap(), Some(0x0E));
+        assert!(take_from(b"\xFF").is_err());
+    }
+
+    #[test]
+    fn der_take_from() {
+        fn take_from<const N: usize>(
+            src: &[u8; N]
+        ) -> Result<Option<usize>, ContentError> {
+            let mut src = SliceSource::new(src.as_ref());
+            let res = Length::<Der>::take_from(&mut src)?;
+            if src.remaining().is_empty() {
+                Ok(res.definite())
+            }
+            else {
+                Err(ContentError::from_static("TRAILING DATA"))
+            }
+        }
+
+        assert_eq!(take_from(b"\x00").unwrap(), Some(0x00));
+        assert_eq!(take_from(b"\x12").unwrap(), Some(0x12));
+        assert_eq!(take_from(b"\x7f").unwrap(), Some(0x7f));
+        assert_eq!(take_from(b"\x80").unwrap(), None);
+        assert!(take_from(b"\x81\x00").is_err());
+        assert!(take_from(b"\x81\x7f").is_err());
+        assert_eq!(take_from(b"\x81\x80").unwrap(), Some(0x80));
+        assert_eq!(take_from(b"\x81\xF0").unwrap(), Some(0xF0));
+        assert!(take_from(b"\x82\x00\x00").is_err());
+        assert_eq!(take_from(b"\x82\xF0\x0E").unwrap(), Some(0xF00E));
+        assert!(take_from(b"\x82\x00\x0E").is_err());
+        assert!(take_from(b"\xFF").is_err());
+    }
+
+    #[test]
+    fn encode() {
+        fn step<const N: usize>(l: Option<usize>, res: &[u8; N]) {
+            let l = Length::<Ber>::new(l);
+            let mut vec = Vec::new();
+            l.append_encoded(&mut vec);
+            assert_eq!(
+                vec.as_slice(), res.as_ref(),
+                "append failed for {l:?}: {vec:?}"
+            );
+
+            let mut vec = Vec::new();
+            l.write_encoded(&mut vec).unwrap();
+            assert_eq!(
+                vec.as_slice(), res.as_ref(),
+                "write failed for {l:?}: {vec:?}"
+            );
+        }
+
+        step(None, b"\x80");
+        step(Some(0), b"\x00");
+        step(Some(0x12), b"\x12");
+        step(Some(0x7f), b"\x7f");
+        step(Some(0x80), b"\x81\x80");
+        step(Some(0xdead), b"\x82\xde\xad");
+    }
+}
+

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -1,82 +1,69 @@
 //! The BER mode.
 //!
-//! This is a private module. It’s public items are re-exported by the parent.
-
-use crate::decode;
-use crate::decode::DecodeError;
+//! 
 
 
-//------------ Mode ----------------------------------------------------------
-
-/// The BER Mode.
+/// Basic Encoding Rules.
 ///
-/// X.680 defines not one but three sets of related encoding rules. All three
-/// follow the same basic ideas but implement them in slightly different
-/// ways.
-///
-/// This type represents these rules. The [`decode`] method provides a way to
-/// decode a source using the specific decoding mode. You can also change
-/// the decoding mode later on through the `set_mode` methods of [`Primitive`]
-/// and [`Constructed`].
-///
-/// [`decode´]: #method.decode
-/// [`Primitive`]: decode/struct.Primitive.html
-/// [`Constructed`]: decode/struct.Constructed.html
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum Mode {
-    /// Basic Encoding Rules.
-    ///
-    /// These are the most flexible rules, allowing alternative encodings for
-    /// some types as well as indefinite length values.
-    #[default]
-    Ber,
+/// These are the most flexible rules, allowing alternative encodings for
+/// some types as well as indefinite length values.
+//
+//  XXX We derive all the things for now so we can derive them on types that
+//      are generic over the mode but will replace the derives later.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Ber;
 
-    /// Canonical Encoding Rules.
-    ///
-    /// These rules always employ indefinite length encoding for constructed
-    /// values and the shortest possible form for primitive values.  There
-    /// are additional restrictions for certain types.
-    Cer,
+/// Canonical Encoding Rules.
+///
+/// These rules always employ indefinite length encoding for constructed
+/// values and the shortest possible form for primitive values.  There
+/// are additional restrictions for certain types.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Cer;
 
-    /// Distinguished Encoding Rules.
-    ///
-    /// These rules always employ definite length values and require the
-    /// shortest possible encoding. Additional rules apply to some types.
-    Der,
+/// Distinguished Encoding Rules.
+///
+/// These rules always employ definite length values and require the
+/// shortest possible encoding. Additional rules apply to some types.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Der;
+
+/// One of the restricted rules CER or DER.
+///
+/// Some restrictions to the basic rules are shared between CER and DER.
+/// This trait allows implementations to do both.
+pub trait Restricted { }
+
+impl Restricted for Cer { }
+impl Restricted for Der { }
+
+/// One of the modes.
+pub trait Mode {
+    /// Is this mode CER or DER?
+    const IS_RESTRICTED: bool;
+
+    /// Does this mode allow definite-length constructed values?
+    const ALLOW_DEFINITE_CONSTRUCTED: bool;
+
+    /// Does this mode allow indefinite length constructed values?
+    const ALLOW_INDEFINITE_CONSTRUCTED: bool;
 }
 
-impl Mode {
-    /// Decode a source using a specific mode.
-    ///
-    /// The method will attempt to decode `source` using the rules represented
-    /// by this value. The closure `op` will be given the content of the
-    /// source as a sequence of values. The closure does not need to process
-    /// all values in the source.
-    pub fn decode<S, F, T>(
-        self, source: S, op: F,
-    ) -> Result<T, DecodeError<<S::Source as decode::Source>::Error>>
-    where
-        S: decode::IntoSource,
-        F: FnOnce(
-            &mut decode::Constructed<S::Source>
-        ) -> Result<T, DecodeError<<S::Source as decode::Source>::Error>>,
-    {
-        decode::Constructed::decode(source, self, op)
-    }
+impl Mode for Ber {
+    const IS_RESTRICTED: bool = false;
+    const ALLOW_DEFINITE_CONSTRUCTED: bool = true;
+    const ALLOW_INDEFINITE_CONSTRUCTED: bool = true;
+}
 
-    /// Returns whether the mode is `Mode::Ber`.
-    pub fn is_ber(self) -> bool {
-        matches!(self, Mode::Ber)
-    }
+impl Mode for Cer {
+    const IS_RESTRICTED: bool = true;
+    const ALLOW_DEFINITE_CONSTRUCTED: bool = false;
+    const ALLOW_INDEFINITE_CONSTRUCTED: bool = true;
+}
 
-    /// Returns whether the mode is `Mode::Cer`.
-    pub fn is_cer(self) -> bool {
-        matches!(self, Mode::Cer)
-    }
-
-    /// Returns whether the mode is `Mode::Der`.
-    pub fn is_der(self) -> bool {
-        matches!(self, Mode::Der)
-    }
+impl Mode for Der {
+    const IS_RESTRICTED: bool = true;
+    const ALLOW_DEFINITE_CONSTRUCTED: bool = true;
+    const ALLOW_INDEFINITE_CONSTRUCTED: bool = false;
 }
 


### PR DESCRIPTION
This PR redesigns how decoding works. The principles are still the same, however, the PR changes how the encoding mode is handled – i.e., whether data is in BER, CER, or DER encoding. This has now become a type argument for all the types involved in decoding. This will allow dedicated implementations particularly for the string types, which are much simpler in DER.

Somewhat more importantly, the `Source` trait has changed. It now enforces that the number of bytes you advance over is equal to the number you have received from the source. This allows to make decoding nearly entirely free of panics, there are only a few instances where slice indexing and other panicking methods are necessary and they are now concentrated in very few places, essentially treating this like unsafe code.

The way this now works is that you request some data from the source which it will give to you as a new value called a fragment. You can ask the fragment for the slice of data it contains (which may still be shorter than what you requested) and, if you so desire, you can “consume” the fragment and advance the source past the data contained in the fragment. If you just drop the fragment, the source doesn’t advance.

> Side note: I would love to be able to force users to drop the fragment by explicitly calling one of two methods, but that doesn’t seem to be possible in Rust right now. So there is still a risk that you forget to consume a fragment, but I suppose that’s what tests are for.

This PR is currently a draft as I didn’t manage to complete it before the Easter break. As such, it won’t even compile.