### PR TITLE
Fix UTF-8 validation to reject invalid code points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 **/*.rs.bk
 /Cargo.lock
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /Cargo.lock
+.worktrees/

--- a/src/string/restricted.rs
+++ b/src/string/restricted.rs
@@ -359,12 +359,16 @@ impl CharSet for Utf8CharSet {
             return Err(CharSetError)
         }
         if first < 0xE0 {
-            return Ok(Some(unsafe {
-                char::from_u32_unchecked(
-                    ((u32::from(first & 0x1F)) << 6) |
-                    u32::from(second & 0x3F)
-                )
-            }))
+            let codepoint = ((u32::from(first & 0x1F)) << 6) |
+                           u32::from(second & 0x3F);
+            // Reject overlong encoding: 2-byte sequence must encode >= 0x80
+            if codepoint < 0x80 {
+                return Err(CharSetError)
+            }
+            return match char::from_u32(codepoint) {
+                Some(ch) => Ok(Some(ch)),
+                None => Err(CharSetError)
+            }
         }
         let third = match iter.next() {
             Some(ch) => ch,
@@ -374,13 +378,17 @@ impl CharSet for Utf8CharSet {
             return Err(CharSetError)
         }
         if first < 0xF0 {
-            return Ok(Some(unsafe {
-                char::from_u32_unchecked(
-                    ((u32::from(first & 0x0F)) << 12) |
-                    ((u32::from(second & 0x3F)) << 6) |
-                    u32::from(third & 0x3F)
-                )
-            }))
+            let codepoint = ((u32::from(first & 0x0F)) << 12) |
+                           ((u32::from(second & 0x3F)) << 6) |
+                           u32::from(third & 0x3F);
+            // Reject overlong encoding: 3-byte sequence must encode >= 0x800
+            if codepoint < 0x800 {
+                return Err(CharSetError)
+            }
+            return match char::from_u32(codepoint) {
+                Some(ch) => Ok(Some(ch)),
+                None => Err(CharSetError)
+            }
         }
         let fourth = match iter.next() {
             Some(ch) => ch,
@@ -389,14 +397,18 @@ impl CharSet for Utf8CharSet {
         if first > 0xF7 || fourth < 0x80 {
             return Err(CharSetError)
         }
-        Ok(Some(unsafe {
-            char::from_u32_unchecked(
-                ((u32::from(first & 0x07)) << 18) |
-                ((u32::from(second & 0x3F)) << 12) |
-                ((u32::from(third & 0x3F)) << 6) |
-                u32::from(fourth & 0x3F)
-            )
-        }))
+        let codepoint = ((u32::from(first & 0x07)) << 18) |
+                       ((u32::from(second & 0x3F)) << 12) |
+                       ((u32::from(third & 0x3F)) << 6) |
+                       u32::from(fourth & 0x3F);
+        // Reject overlong encoding: 4-byte sequence must encode >= 0x10000
+        if codepoint < 0x10000 {
+            return Err(CharSetError)
+        }
+        match char::from_u32(codepoint) {
+            Some(ch) => Ok(Some(ch)),
+            None => Err(CharSetError)
+        }
     }
 
     fn from_str(s: &str) -> Result<Cow<'_, [u8]>, CharSetError> {
@@ -567,5 +579,30 @@ mod test {
     fn should_restrict_printable_string() {
         let os = OctetString::new(Bytes::from_static(b"This is wrong!"));
         assert!(PrintableString::new(os).is_err());
+    }
+
+    #[test]
+    fn should_reject_surrogate_code_points() {
+        // Surrogate U+D800: bytes ED A0 80
+        let os = OctetString::new(Bytes::from_static(b"\xed\xa0\x80"));
+        assert!(Utf8String::new(os).is_err(), "should reject surrogate U+D800");
+
+        // Surrogate U+DFFF: bytes ED BF BF
+        let os = OctetString::new(Bytes::from_static(b"\xed\xbf\xbf"));
+        assert!(Utf8String::new(os).is_err(), "should reject surrogate U+DFFF");
+    }
+
+    #[test]
+    fn should_reject_overlong_encoding() {
+        // Overlong encoding of U+0000: C0 80
+        let os = OctetString::new(Bytes::from_static(b"\xc0\x80"));
+        assert!(Utf8String::new(os).is_err(), "should reject overlong encoding");
+    }
+
+    #[test]
+    fn should_reject_above_max_unicode() {
+        // U+110000 (above max valid Unicode): F4 90 80 80
+        let os = OctetString::new(Bytes::from_static(b"\xf4\x90\x80\x80"));
+        assert!(Utf8String::new(os).is_err(), "should reject code points above U+10FFFF");
     }
 }


### PR DESCRIPTION
## Summary

Fixes a soundness issue in UTF-8 string validation that could create invalid `char` values from malformed UTF-8 sequences, leading to undefined behavior.

## Problem

The `Utf8CharSet::next_char` implementation used `char::from_u32_unchecked` without proper validation, accepting:
- Surrogate code points (U+D800..U+DFFF)
- Code points above maximum Unicode (>U+10FFFF)
- Overlong UTF-8 encodings

This violated Rust safety guarantees and could cause memory corruption or process termination.

## Solution

- Replaced `unsafe char::from_u32_unchecked` with safe `char::from_u32`
- Added validation for minimum encoding lengths to reject overlong sequences
- `char::from_u32` inherently rejects surrogates and out-of-range values

## Testing

Added three test cases verifying rejection of:
- Surrogate code points (U+D800, U+DFFF)
- Overlong encodings (e.g., C0 80 for U+0000)
- Above-maximum values (e.g., U+110000)

All existing tests continue to pass.

## Impact

This is a critical security fix that prevents undefined behavior from untrusted input (e.g., X.509 certificates with UTF8String fields).