### PR TITLE
Fix panic in Unsigned::from_bytes for all-zero input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 **/*.rs.bk
 /Cargo.lock
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /Cargo.lock
+.worktrees/

--- a/src/int.rs
+++ b/src/int.rs
@@ -469,6 +469,13 @@ impl Unsigned {
         }).count();
         let value = bytes.slice(num_leading_zero_bytes..);
 
+        // Handle all-zero input: return canonical zero encoding
+        if value.is_empty() {
+            return unsafe { Ok(Unsigned::from_bytes_unchecked(
+                Bytes::from_static(&[0x00])
+            ))}
+        }
+
         // Create a new Unsigned integer from the given value bytes, ensuring
         // that the most-significant bit is zero.
         let new_bytes = if value[0] & 0x80 == 0 {


### PR DESCRIPTION
## Summary

Fixes a panic (denial-of-service) in `Unsigned::from_bytes` when all input bytes are zero.

## Problem

When `Unsigned::from_bytes` receives input where all bytes are `0x00` (e.g., `[0x00]` or `[0x00, 0x00]`), the function:
1. Counts all bytes as leading zeros
2. Creates an empty `value` slice
3. Attempts to access `value[0]`, causing an index-out-of-bounds panic

This is a valid input representing the unsigned integer 0, so it should succeed rather than panic.

## Solution

Added a check after stripping leading zeros: if the `value` slice is empty, return the canonical zero encoding `[0x00]`.

## Impact

- Prevents denial-of-service from valid zero inputs
- Maintains backward compatibility (zero inputs now succeed instead of panic)
- All existing tests continue to pass