### PR TITLE
Fix BitString::bit bounds check for unused bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 **/*.rs.bk
 /Cargo.lock
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /Cargo.lock
+.worktrees/

--- a/src/string/bit.rs
+++ b/src/string/bit.rs
@@ -383,5 +383,22 @@ mod test {
         check(b"\x03\x01\x04", None);
         check(b"\x03\x00", None);
     }
+
+    #[test]
+    fn bitstring_bit() {
+        let b = BitString::new(0, Bytes::from_static(b"\xFF\xff"));
+        assert_eq!(b.bit(0), true);
+        assert_eq!(b.bit(15), true);
+        assert_eq!(b.bit(16), false);
+        assert_eq!(b.bit(24), false);
+
+        let b = BitString::new(2, Bytes::from_static(b"\xFF\xfc"));
+        assert_eq!(b.bit(0), true);
+        assert_eq!(b.bit(13), true);
+        assert_eq!(b.bit(14), false);
+        assert_eq!(b.bit(15), false);
+        assert_eq!(b.bit(16), false);
+        assert_eq!(b.bit(24), false);
+    }
 }
 

--- a/src/string/bit.rs
+++ b/src/string/bit.rs
@@ -90,7 +90,7 @@ impl BitString {
             return false
         }
         let bit = 7 - (bit as u8 & 7);
-        if self.bits.len() + 1 == idx && self.unused > bit {
+        if self.bits.len() - 1 == idx && self.unused > bit {
             return false
         }
         self.bits[idx] & (1 << bit) != 0


### PR DESCRIPTION
Fixes incorrect bounds check that allowed reading garbage values from unused bits in the last octet. Changed unreachable condition from len+1==idx to len-1==idx.