### PR TITLE
Fix Integer::is_zero to check entire value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /Cargo.lock
+.worktrees/

--- a/src/int.rs
+++ b/src/int.rs
@@ -258,7 +258,7 @@ impl Integer {
 
     /// Returns whether the number is zero.
     pub fn is_zero(&self) -> bool {
-        self.0[0] == 0
+        self.0.len() == 1 && self.0[0] == 0
     }
 
     /// Returns whether the integer is positive.


### PR DESCRIPTION
Fixes incorrect is_zero() implementation that only checked the first byte, returning true for non-zero multi-byte integers starting with 0x00. Now correctly checks for single-byte zero.