### PR TITLE
Fix overflow panic in `Oid` FromStr on large second arc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,14 @@ Improvements
 
 Bug fixes
 
+* Fixed a panic in the `FromStr` implementation for `Oid` when the combined
+  first subidentifier (`40 * first + second`) of an OID overflows `u32`, e.g.
+  `"2.4294967295"`. Such input is now rejected with an error instead of
+  panicking in overflow-checking builds. ([#101])
+
 Other changes
+
+[#101]: https://github.com/NLnetLabs/bcder/issues/101
 
 
 ## 0.7.7

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -269,7 +269,16 @@ impl<T: AsRef<[u8]> + From<Vec<u8>>> FromStr for Oid<T> {
             return Err("second component for 0. and 1. must be less than 40");
         }
 
-        let mut res = vec![40 * first + second];
+        // The first two arcs are combined into a single subidentifier as
+        // `40 * first + second`. For `first == 2` the second arc is
+        // unbounded, so this can exceed `u32::MAX`; use checked arithmetic
+        // to return an error instead of overflowing.
+        let first_subidentifier = first
+            .checked_mul(40)
+            .and_then(|v| v.checked_add(second))
+            .ok_or("OID component out of range")?;
+
+        let mut res = vec![first_subidentifier];
         for item in components {
             res.push(from_str(item)?);
         }
@@ -514,5 +523,30 @@ mod test {
         check(b"\x81\x34\x83\x03", true);
         check(b"\x81\x34\x83\x83\x03\x03", true);
         check(b"\x81\x34\x83", false);
+    }
+
+    #[test]
+    fn from_str() {
+        use std::str::FromStr;
+
+        // Well-formed OIDs round-trip to the expected encoding.
+        assert_eq!(
+            Oid::<Vec<u8>>::from_str("2.5.29.19").unwrap().0,
+            vec![85, 29, 19]
+        );
+        // A large second arc under `first == 2` is representable.
+        assert!(Oid::<Vec<u8>>::from_str("2.100.3").is_ok());
+
+        // Malformed inputs are rejected without panicking.
+        assert!(Oid::<Vec<u8>>::from_str("").is_err());
+        assert!(Oid::<Vec<u8>>::from_str("2").is_err());
+        assert!(Oid::<Vec<u8>>::from_str("3.5").is_err());
+        assert!(Oid::<Vec<u8>>::from_str("1.40").is_err());
+        assert!(Oid::<Vec<u8>>::from_str("1.x").is_err());
+
+        // Regression for #101: a second component that makes the combined
+        // first subidentifier exceed `u32::MAX` must return an error rather
+        // than overflow-panic in overflow-checking builds.
+        assert!(Oid::<Vec<u8>>::from_str("2.4294967295").is_err());
     }
 }


### PR DESCRIPTION
Fixes #101.

## Problem

`<Oid as FromStr>::from_str` panics on an OID whose second arc is large enough to overflow the combined first subidentifier:

```rust
use std::str::FromStr;
use bcder::Oid;

Oid::<Vec<u8>>::from_str("2.4294967295"); // panics: attempt to add with overflow
```

The first two arcs are packed into a single subidentifier as `40 * first + second` (`src/oid.rs`). The semantic check only bounds `second` when `first < 2`:

```rust
if first < 2 && second >= 40 {
    return Err("second component for 0. and 1. must be less than 40");
}
let mut res = vec![40 * first + second];
```

For `first == 2` the second arc is unbounded, so a large `second` (e.g. `u32::MAX`) passes validation and then overflows the `u32` addition, panicking in debug / overflow-checking builds.

## Fix

Compute the first subidentifier with checked arithmetic and return the function's existing `&'static str` error when the value is not representable, instead of overflowing:

```rust
let first_subidentifier = first
    .checked_mul(40)
    .and_then(|v| v.checked_add(second))
    .ok_or("OID component out of range")?;
```

The public signature (`Result<Self, &'static str>`) is unchanged, and well-formed OIDs — including representable large second arcs under `first == 2` such as `"2.100.3"` — keep parsing exactly as before.

## Tests

Adds an `oid::test::from_str` regression test in `src/oid.rs` covering:

* the overflow input `"2.4294967295"` (now `Err`, previously a panic);
* representative well-formed OIDs (`"2.5.29.19"` round-trips to `[85, 29, 19]`, `"2.100.3"` is `Ok`);
* malformed inputs (empty, single component, first arc `> 2`, second arc `>= 40` under `first < 2`, non-integer component).

Verified **red without the fix** (`attempt to add with overflow` at `src/oid.rs`) and **green with it**. Full suite passes: `cargo test --all --all-features` (38 unit + 6 doc tests) and `cargo clippy --all --all-features -- -D warnings` is clean.

Also adds a `Bug fixes` entry to the `Unreleased` section of `Changelog.md`.
