### PR TITLE
Fix panic in Oid::from_str with large second component.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,14 @@ Improvements
 
 Bug fixes
 
+* Fixed a panic in `Oid::from_str` when the first component is 2 and the
+  second component is too slightly too large. ([#103], reported by
+  [@xc01])
+
 Other changes
+
+[#103]: https://github.com/NLnetLabs/bcder/pull/103
+[@xc01]: https://github.com/xc01
 
 
 ## 0.7.7

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -270,9 +270,10 @@ impl<T: AsRef<[u8]> + From<Vec<u8>>> FromStr for Oid<T> {
         }
 
         let mut res = vec![
-            first.checked_mul(40).and_then(|first| {
-                first.checked_add(second)
-            }).ok_or("overflow in second component")?
+            // Panic: first is between 0 and 2, so times 40 will always fit.
+            (40 * first).checked_add(second).ok_or(
+                "overflow in second component"
+            )?
         ];
         for item in components {
             res.push(from_str(item)?);
@@ -493,6 +494,7 @@ mod test {
             Oid(&[85, 29, 19])
         );
         assert!(Oid::<Vec<u8>>::from_str("2.4294967295").is_err());
+        assert!(Oid::<Vec<u8>>::from_str("3.4294967295").is_err());
     }
 
     #[test]

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -269,7 +269,11 @@ impl<T: AsRef<[u8]> + From<Vec<u8>>> FromStr for Oid<T> {
             return Err("second component for 0. and 1. must be less than 40");
         }
 
-        let mut res = vec![40 * first + second];
+        let mut res = vec![
+            first.checked_mul(40).and_then(|first| {
+                first.checked_add(second)
+            }).ok_or("overflow in second component")?
+        ];
         for item in components {
             res.push(from_str(item)?);
         }
@@ -481,6 +485,15 @@ impl<'a> Iterator for Iter<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn from_str() {
+        assert_eq!(
+            Oid::<Vec<u8>>::from_str("2.5.29.19").unwrap(),
+            Oid(&[85, 29, 19])
+        );
+        assert!(Oid::<Vec<u8>>::from_str("2.4294967295").is_err());
+    }
 
     #[test]
     fn display() {


### PR DESCRIPTION
This PR fixes a panic in `Oid::from_str` when the first component is 2 and the second component is just too large to have 80 added to it and still fit.

Reported by @xc01.

Fixes #101.